### PR TITLE
"Automatic" route registration

### DIFF
--- a/includes/abstracts/class-llms-rest-controller.php
+++ b/includes/abstracts/class-llms-rest-controller.php
@@ -113,4 +113,95 @@ abstract class LLMS_REST_Controller extends WP_REST_Controller {
 
 	}
 
+	/**
+	 * Retrieves the query params for retrieving a single resource.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function get_get_item_params() {
+
+		return array(
+			'context' => $this->get_context_param( array(
+				'default' => 'view'
+			) ),
+		);
+
+	}
+
+	/**
+	 * Retrieve arguments for deleting a resource.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function get_delete_item_args() {
+		return array();
+	}
+
+	/**
+	 * Register routes.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'lifterlms' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_get_item_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ), // see class-wp-rest-controller.php.
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => $this->get_delete_item_args(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+	}
+
 }

--- a/includes/abstracts/class-llms-rest-controller.php
+++ b/includes/abstracts/class-llms-rest-controller.php
@@ -123,9 +123,11 @@ abstract class LLMS_REST_Controller extends WP_REST_Controller {
 	public function get_get_item_params() {
 
 		return array(
-			'context' => $this->get_context_param( array(
-				'default' => 'view'
-			) ),
+			'context' => $this->get_context_param(
+				array(
+					'default' => 'view',
+				)
+			),
 		);
 
 	}

--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -45,81 +45,6 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	);
 
 	/**
-	 * Register routes.
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function register_routes() {
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args'                => $this->get_collection_params(),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_item' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), // see class-wp-rest-controller.php.
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		$schema        = $this->get_item_schema();
-		$get_item_args = array(
-			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
-		);
-
-		if ( isset( $schema['properties']['password'] ) ) {
-			$get_item_args['password'] = array(
-				'description' => __( 'Post password. Required if the post is password protected.', 'lifterlms' ),
-				'type'        => 'string',
-			);
-		}
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\d]+)',
-			array(
-				'args'   => array(
-					'id' => array(
-						'description' => __( 'Unique identifier for the object.', 'lifterlms' ),
-						'type'        => 'integer',
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
-					'args'                => $get_item_args,
-				),
-				array(
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'update_item' ),
-					'permission_callback' => array( $this, 'update_item_permissions_check' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ), // see class-wp-rest-controller.php.
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $this, 'delete_item' ),
-					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
-					'args'                => $this->get_delete_item_args(),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-	}
-
-	/**
 	 * Retrieves an array of arguments for the delete endpoint.
 	 *
 	 * @since [version]
@@ -135,6 +60,29 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 				'default'     => false,
 			),
 		);
+
+	}
+
+	/**
+	 * Retrieves the query params for retrieving a single resource.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function get_get_item_params() {
+
+		$params = parent::get_get_item_params();
+		$schema = $this->get_item_schema();
+
+		if ( isset( $schema['properties']['password'] ) ) {
+			$params['password'] = array(
+				'description' => __( 'Post password. Required if the post is password protected.', 'lifterlms' ),
+				'type'        => 'string',
+			);
+		}
+
+		return $params;
 
 	}
 

--- a/includes/abstracts/class-llms-rest-users-controller.php
+++ b/includes/abstracts/class-llms-rest-users-controller.php
@@ -17,4 +17,7 @@ defined( 'ABSPATH' ) || exit;
  */
 abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 
+
+
+
 }

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -36,77 +36,36 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	);
 
 	/**
-	 * Register routes.
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function register_routes() {
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base,
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => $this->get_collection_params(),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_item' ),
-					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), // see class-wp-rest-controller.php.
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\d]+)',
-			array(
-				'args'   => array(
-					'id' => array(
-						'description' => __( 'API Key Identifier.', 'lifterlms' ),
-						'type'        => 'integer',
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => array(),
-				),
-				array(
-					'methods'             => WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'update_item' ),
-					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ), // see class-wp-rest-controller.php.
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $this, 'delete_item' ),
-					'permission_callback' => array( $this, 'check_permissions' ),
-					'args'                => array(),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-	}
-
-	/**
 	 * Check if the authenticated user can perform the request action.
 	 *
 	 * @since [version]
 	 *
 	 * @return boolean
 	 */
-	public function check_permissions() {
+	protected function check_permissions() {
 		return current_user_can( 'manage_lifterlms_api_keys' ) ? true : llms_rest_authorization_required_error();
+	}
+
+	/**
+	 * Check if a given request has access to create an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		return $this->check_permissions();
+	}
+
+	/**
+	 * Check if a given request has access to delete an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		return $this->check_permissions();
 	}
 
 	/**
@@ -195,6 +154,30 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 			),
 		);
 
+	}
+
+	/**
+	 * Check if a given request has access to read an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->check_permissions();
+	}
+
+	/**
+	 * Check if a given request has access to read items.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		return $this->check_permissions();
 	}
 
 	/**
@@ -501,6 +484,18 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	}
 
 	/**
+	 * Check if a given request has access to update an item.
+	 *
+	 * @since [version]
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		return $this->check_permissions();
+	}
+
+	/**
 	 * Validate submitted user IDs are real user ids.
 	 *
 	 * @since [version]
@@ -516,5 +511,3 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	}
 
 }
-
-return new LLMS_REST_API_Keys_Controller();

--- a/tests/unit-tests/server/class-llms-rest-test-api-keys-controller.php
+++ b/tests/unit-tests/server/class-llms-rest-test-api-keys-controller.php
@@ -159,6 +159,48 @@ class LLMS_REST_Test_API_Keys_Controller extends LLMS_REST_Unit_Test_Case_Server
 	}
 
 	/**
+	 * Test the permissions check methods.
+	 *
+	 * @return void
+	 */
+	public function test_check_permissions() {
+
+		$request = new WP_REST_Request( 'GET', $this->route );
+
+		$methods = array(
+			'create_item_permissions_check',
+			'delete_item_permissions_check',
+			'get_item_permissions_check',
+			'get_items_permissions_check',
+			'update_item_permissions_check',
+		);
+
+		// No user.
+		wp_set_current_user( null );
+		foreach ( $methods as $method ) {
+			$res = $this->endpoint->{$method}( $request );
+			$this->assertIsWPError( $res );
+			$this->assertWPErrorCodeEquals( 'llms_rest_unauthorized_request', $res );
+		}
+
+
+		// Disallowed User.
+		wp_set_current_user( $this->user_forbidden );
+		foreach ( $methods as $method ) {
+			$res = $this->endpoint->{$method}( $request );
+			$this->assertIsWPError( $res );
+			$this->assertWPErrorCodeEquals( 'llms_rest_forbidden_request', $res );
+		}
+
+		// Allowed User.
+		wp_set_current_user( $this->user_allowed );
+		foreach ( $methods as $method ) {
+			$this->assertTrue( $this->endpoint->{$method}( $request ) );
+		}
+
+	}
+
+	/**
 	 * test the delete_item() method.
 	 *
 	 * @since [version]


### PR DESCRIPTION
Route registration is moved to a method in the `LLMS_REST_Controller` class which will automatically register general routes based off the `$namespace` and `$rest_base` class properties for:

+ Get collection: `GET /resources`
+ Create resource: `POST /resources`
+ Get resource: `GET /resources/{id}`
+ Update resource: `POST /resources/{id}`
+ Delete resource: `DELETE /resources/{id}`

All core resources will have (at least) these routes available.

Additional resources can be registered by overriding the method, calling the parent method, and adding additional routes in the child method.

All endpoint controllers will be required to define a `{method}_item` and `{method}_item_permissions_check` method.

Arguments/parameters for each endpoint may be configured via the corresponding method for the method. Method stubs have been added to the abstract returning an empty array. Child classes can override to define the arguments for the endpoint:

+ `get_collection_params()` (preexisting)
+ `get_endpoint_args_for_item_schema( $method )` (preexisting)
+ `get_get_item_params()` (new, for defining query parameters available for a request to read a single resource)
+ `get_delete_item_args()` (ported from the posts controller abstract, used for defining arguments for deleting an item).
