### PR TITLE
Courses various fixes

### DIFF
--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -16,10 +16,19 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.1
  * @since [version] Make `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.
  *                     In `update_additional_object_fields()` method, use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
+ *
  *                     Allow `prerequisite` and `prerequisite_track` to be cleared (set to 0).
  *                     Also:
  *                     - if `prerequisite` is not a valid course the course `prerequisite` will be set to 0;
  *                     - if `prerequisite_track` is not a valid course track, the course `prerequisite_track` will be set to 0.
+ *
+ *                     `update_additional_object_fields()` returns false if nothing to update.
+ *
+ *                     Properties `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` handling
+ *                     moved here from `prepare_item_for_database()` method to `update_additional_object_fields()` method so to better handle the update of the
+ *                     course's properties `time_period` and `enrollment_period`.
+ *                     Added logic to prevent trying to update "derived only" courses's properties (`time_period`, `enrollment_period`, `has_prerequisite`)
+ *                     if their values didn't really change, otherwise we'd get a WP_Error which the consumer cannot avoid having no direct control on those properties.
  */
 class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
@@ -631,9 +640,15 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 * Prepares a single post for create or update.
 	 *
 	 * @since 1.0.0-beta.1
-	 * @since [version] Make `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.
+	 * @since [version] `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date`
+	 *                     treated in @see `update_additional_object_fields()` method so to better handle the update of the
+	 *                     course's properties `time_period` and `enrollment_period` whose values are derived from them and need to be
+	 *                     passed to `$course->set_bulk()` only if they differ from their current values, otherwise we'd get a WP_Error
+	 *                     which the consumer cannot avoid having no direct control on those properties.
 	 *
-	 * @param WP_REST_Request $request  Request object.
+	 * Make `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.
+	 *
+	 * @param WP_REST_Request $request Request object.
 	 * @return array|WP_Error Array of llms post args or WP_Error.
 	 */
 	protected function prepare_item_for_database( $request ) {
@@ -693,42 +708,6 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			}
 		}
 
-		// Access dates.
-		if ( ! empty( $schema['properties']['access_opens_date'] ) && isset( $request['access_opens_date'] ) ) {
-			$access_opens_date           = rest_parse_date( $request['access_opens_date'] );
-			$prepared_item['start_date'] = empty( $access_opens_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $access_opens_date );
-		}
-
-		if ( ! empty( $schema['properties']['access_closes_date'] ) && isset( $request['access_closes_date'] ) ) {
-			$access_closes_date        = rest_parse_date( $request['access_closes_date'] );
-			$prepared_item['end_date'] = empty( $access_closes_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $access_closes_date );
-		}
-
-		// Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
-		if ( ! empty( $prepared_item['start_date'] ) || ! empty( $prepared_item['end_date'] ) ) {
-			$prepared_item['time_period'] = 'yes';
-		} else {
-			$prepared_item['time_period'] = 'no';
-		}
-
-		// Enrollment dates.
-		if ( ! empty( $schema['properties']['enrollment_opens_date'] ) && isset( $request['enrollment_opens_date'] ) ) {
-			$enrollment_opens_date                  = rest_parse_date( $request['enrollment_opens_date'] );
-			$prepared_item['enrollment_start_date'] = empty( $enrollment_opens_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $enrollment_opens_date );
-		}
-
-		if ( ! empty( $schema['properties']['enrollment_closes_date'] ) && isset( $request['enrollment_closes_date'] ) ) {
-			$enrollment_closes_date               = rest_parse_date( $request['enrollment_closes_date'] );
-			$prepared_item['enrollment_end_date'] = empty( $enrollment_closes_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $enrollment_closes_date );
-		}
-
-		// Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
-		if ( ! empty( $prepared_item['enrollment_start_date'] ) || ! empty( $prepared_item['enrollment_end_date'] ) ) {
-			$prepared_item['enrollment_period'] = 'yes';
-		} else {
-			$prepared_item['enrollment_period'] = 'no';
-		}
-
 		// Sales page.
 		if ( ! empty( $schema['properties']['sales_page_page_type'] ) && isset( $request['sales_page_page_type'] ) ) {
 			$prepared_item['sales_page_content_type'] = $request['sales_page_page_type'];
@@ -752,7 +731,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	}
 
 	/**
-	 * Updates a single llms post.
+	 * Updates a single llms course.
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since [version] Use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
@@ -761,12 +740,23 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 *                     - if `prerequisite` is not a valid course the course `prerequisite` will be set to 0;
 	 *                     - if `prerequisite_track` is not a valid course track, the course `prerequisite_track` will be set to 0.
 	 *
+	 *                     Return false if nothing to update.
+	 *
+	 *                     Properties `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` handling
+	 *                     moved here from `prepare_item_for_database()` method so to better handle the update of the
+	 *                     course's properties `time_period` and `enrollment_period`.
+	 *
+	 *                     Made `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` properties nullable.
+	 *
+	 *                     Added logic to prevent trying to update "derived only" courses's properties (`time_period`, `enrollment_period`, `has_prerequisite`)
+	 *                     if their values didn't really change, otherwise we'd get a WP_Error which the consumer cannot avoid having no direct control on those properties.
+	 *
 	 * @param LLMS_Course     $course        LLMS_Course instance.
 	 * @param WP_REST_Request $request       Full details about the request.
 	 * @param array           $schema        The item schema.
 	 * @param array           $prepared_item Array.
 	 * @param bool            $creating      Optional. Whether we're in creation or update phase. Default true (create).
-	 * @return bool|WP_Error True on success, WP_Error object otherwise.
+	 * @return bool|WP_Error True on success or false if nothing to update, WP_Error object if something went wrong during the update.
 	 */
 	protected function update_additional_object_fields( $course, $request, $schema, $prepared_item, $creating = true ) {
 
@@ -796,6 +786,42 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		$to_set = array();
+
+		// Access dates.
+		if ( ! empty( $schema['properties']['access_opens_date'] ) && isset( $request['access_opens_date'] ) ) {
+			$access_opens_date    = rest_parse_date( $request['access_opens_date'] );
+			$to_set['start_date'] = empty( $access_opens_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $access_opens_date );
+		}
+
+		if ( ! empty( $schema['properties']['access_closes_date'] ) && isset( $request['access_closes_date'] ) ) {
+			$access_closes_date = rest_parse_date( $request['access_closes_date'] );
+			$to_set['end_date'] = empty( $access_closes_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $access_closes_date );
+		}
+
+		// Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
+		if ( ! empty( $to_set['start_date'] ) || ! empty( $to_set['end_date'] ) ) {
+			$to_set['time_period'] = 'yes';
+		} else {
+			$to_set['time_period'] = 'no';
+		}
+
+		// Enrollment dates.
+		if ( ! empty( $schema['properties']['enrollment_opens_date'] ) && isset( $request['enrollment_opens_date'] ) ) {
+			$enrollment_opens_date           = rest_parse_date( $request['enrollment_opens_date'] );
+			$to_set['enrollment_start_date'] = empty( $enrollment_opens_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $enrollment_opens_date );
+		}
+
+		if ( ! empty( $schema['properties']['enrollment_closes_date'] ) && isset( $request['enrollment_closes_date'] ) ) {
+			$enrollment_closes_date        = rest_parse_date( $request['enrollment_closes_date'] );
+			$to_set['enrollment_end_date'] = empty( $enrollment_closes_date ) ? '' : date_i18n( 'Y-m-d H:i:s', $enrollment_closes_date );
+		}
+
+		// Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
+		if ( ! empty( $to_set['enrollment_start_date'] ) || ! empty( $to_set['enrollment_end_date'] ) ) {
+			$to_set['enrollment_period'] = 'yes';
+		} else {
+			$to_set['enrollment_period'] = 'no';
+		}
 
 		// Prerequisite.
 		if ( ! empty( $schema['properties']['prerequisite'] ) && isset( $request['prerequisite'] ) ) {
@@ -882,6 +908,17 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 					$to_set[ $prop ] = str_replace( '{{course_id}}', $course_id, $to_set[ $prop ] );
 				}
 			}
+		} else { // Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
+			$_props = array(
+				'time_period',
+				'enrollment_period',
+				'has_prerequisite',
+			);
+			foreach ( $_props as $_prop ) {
+				if ( isset( $to_set[ $_prop ] ) && $to_set[ $_prop ] === $course->get( $_prop ) ) {
+					unset( $to_set[ $_prop ] );
+				}
+			}
 		}
 
 		// Set bulk.
@@ -892,7 +929,11 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			}
 		}
 
-		return ! empty( $error->errors ) ? $error : true;
+		if ( $error->has_errors() ) {
+			return $error;
+		}
+
+		return ! empty( $to_set );
 
 	}
 

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -16,6 +16,10 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.1
  * @since [version] Make `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.
  *                     In `update_additional_object_fields()` method, use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
+ *                     Allow `prerequisite` and `prerequisite_track` to be cleared (set to 0).
+ *                     Also:
+ *                     - if `prerequisite` is not a valid course the course `prerequisite` will be set to 0;
+ *                     - if `prerequisite_track` is not a valid course track, the course `prerequisite_track` will be set to 0.
  */
 class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
@@ -752,7 +756,11 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since [version] Use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
-
+	 *                     Allow `prerequisite` and `prerequisite_track` to be ted.
+	 *                     Also:
+	 *                     - if `prerequisite` is not a valid course the course `prerequisite` will be set to 0;
+	 *                     - if `prerequisite_track` is not a valid course track, the course `prerequisite_track` will be set to 0.
+	 *
 	 * @param LLMS_Course     $course        LLMS_Course instance.
 	 * @param WP_REST_Request $request       Full details about the request.
 	 * @param array           $schema        The item schema.
@@ -795,6 +803,8 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			$prerequisite = llms_get_post( $request['prerequisite'] );
 			if ( is_a( $prerequisite, 'LLMS_Course' ) ) {
 				$to_set['prerequisite'] = $request['prerequisite'];
+			} else {
+				$to_set['prerequisite'] = 0;
 			}
 		}
 
@@ -804,6 +814,8 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			$track = new LLMS_Track( $request['prerequisite_track'] );
 			if ( $track->term ) {
 				$to_set['prerequisite_track'] = $request['prerequisite_track'];
+			} else {
+				$to_set['prerequisite_track'] = 0;
 			}
 		}
 

--- a/tests/unit-tests/server/class-llms-rest-test-courses.php
+++ b/tests/unit-tests/server/class-llms-rest-test-courses.php
@@ -999,6 +999,7 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 	 * Test updating a course.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Add tests on prerequisites.
 	 */
 	public function test_update_course() {
 
@@ -1015,9 +1016,7 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 			'status'       => 'draft',
 		);
 
-		$request = new WP_REST_Request( 'POST', $this->route . '/' . $course->get( 'id' ) );
-		$request->set_body_params( $update_data );
-		$response = $this->server->dispatch( $request );
+		$response = $this->perform_mock_request( 'POST', $this->route . '/' . $course->get( 'id' ), $update_data );
 
 		// Success.
 		$this->assertEquals( 200, $response->get_status() );
@@ -1029,6 +1028,38 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 		$this->assertEquals( rtrim( apply_filters( 'the_content', $update_data['content'] ), "\n" ), rtrim( $res_data['content']['rendered'], "\n" ) );
 		$this->assertEquals( $update_data['date_created'], $res_data['date_created'] );
 		$this->assertEquals( $update_data['status'], $res_data['status'] );
+
+		// check the course has no prerequisites.
+		$course = new LLMS_Course( $res_data['id'] );
+		$this->assertFalse( $course->has_prerequisite() );
+
+		// create a course prerequisite.
+		$prerequisite_id       = $this->factory->course->create();
+		$track                 = wp_insert_term( 'mock track', 'course_track' );
+		$prerequisite_track_id = $track['term_id'];
+
+		// Update prerequisites.
+		$update_data = array(
+			'prerequisite'       => (int) $prerequisite_id,
+			'prerequisite_track' => $prerequisite_track_id,
+		);
+
+		$response = $this->perform_mock_request( 'POST', $this->route . '/' . $course->get( 'id' ), $update_data );
+
+		// Success.
+		$this->assertEquals( 200, $response->get_status() );
+
+		$res_data = $response->get_data();
+
+		// check the course has prerequisites.
+		$course = new LLMS_Course( $res_data['id'] );
+		$this->assertTrue( $course->has_prerequisite() );
+		$this->assertTrue( $course->has_prerequisite( 'course' ) );
+		$this->assertTrue( $course->has_prerequisite( 'course_track' ) );
+		$this->assertEquals( $course->get( 'prerequisite' ), $res_data['prerequisite'] );
+		$this->assertEquals( $update_data['prerequisite'], $res_data['prerequisite'] );
+		$this->assertEquals( $course->get( 'prerequisite_track' ), $res_data['prerequisite_track'] );
+		$this->assertEquals( $update_data['prerequisite_track'], $res_data['prerequisite_track'] );
 
 	}
 


### PR DESCRIPTION
Allow 'prerequisite' and 'prerequisite_track' to be cleared (set to 0).
Also:
- if 'prerequisite' is not a valid course the course `prerequisite` will be set to 0;
- if 'prerequisite_track' is not a valid course track, the course `prerequisite_track` will be set to 0.

Don't execute `$object->set_bulk()` when there's no data to update;
when updating, make sure some derived properties such as
`time_period`,
`enrollment_period`,
`has_prerequisite`
are only passed to `$object->set_bulk()` if they actually changed.

@thomasplevy this PR can conflict with #88 so as soon as you merge one of the two to master ping me so that I rebase and adapt the other one, thanks!