### PR TITLE
Courses: support WordPress versions prior to 5.1 by not using WP_Erro…

### DIFF
--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_REST_Courses_Controller
  *
  * @since 1.0.0-beta.1
+ * @since [version] In `update_additional_object_fields()` method, use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
  */
 class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
@@ -748,7 +749,8 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 * Updates a single llms post.
 	 *
 	 * @since 1.0.0-beta.1
-	 *
+	 * @since [version] Use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
+
 	 * @param LLMS_Course     $course        LLMS_Course instance.
 	 * @param WP_REST_Request $request       Full details about the request.
 	 * @param array           $schema        The item schema.
@@ -876,7 +878,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			}
 		}
 
-		return $error->has_errors() ? $error : true;
+		return ! empty( $error->errors ) ? $error : true;
 
 	}
 


### PR DESCRIPTION
…r::has_errors()

**Please note:** This PR is not needed if we merge https://github.com/gocodebox/lifterlms-rest/pull/89, as it includes the backward compatibility code among other fixes.