### PR TITLE
Return links to those taxonomies which have an accessible rest route.

### DIFF
--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.7
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,7 +23,8 @@ defined( 'ABSPATH' ) || exit;
  *                     Fix wp:featured_media link, we don't expose any embeddable field.
  *                     Also `self` and `collection` links prepared in the parent class.
  *                     Added `"llms_rest_insert_{$this->post_type}"` and `"llms_rest_insert_{$this->post_type}"` action hooks:
- *                     fired after inserting/updating an llms post into the database.
+ *                     fired after inserting/updateing an llms post into the database.
+ * @since [version] Return links to those taxonomies which have an accessible rest route.
  */
 abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 
@@ -1191,6 +1192,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.2 Filter taxonomies by `public` property instead of `show_in_rest`.
 	 * @since 1.0.0-beta.3 Filter taxonomies by `show_in_llms_rest` property instead of `public`.
 	 * @since 1.0.0-beta.7 `self` and `collection` links prepared in the parent class.
+	 * @since [version] Return links to those taxonomies which have an accessible rest route.
 	 *
 	 * @param LLMS_Post_Model $object  Object data.
 	 * @return array Links for the given object.
@@ -1224,8 +1226,8 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 			foreach ( $taxonomies as $tax ) {
 				$taxonomy_obj = get_taxonomy( $tax );
 
-				// Skip taxonomies that are not set to be shown in LLMS REST.
-				if ( empty( $taxonomy_obj->show_in_llms_rest ) ) {
+				// Skip taxonomies that are not set to be shown in REST and LLMS REST.
+				if ( empty( $taxonomy_obj->show_in_rest ) || empty( $taxonomy_obj->show_in_llms_rest ) ) {
 					continue;
 				}
 

--- a/tests/unit-tests/server/class-llms-rest-test-courses.php
+++ b/tests/unit-tests/server/class-llms-rest-test-courses.php
@@ -11,7 +11,8 @@
  * @since 1.0.0-beta.7 Block migration forcing and db cleanup moved to LLMS_REST_Unit_Test_Case_Posts::setUp().
  * @since [version]  When retrieving a course, added check on `sales_page_*` defaults.
  *                     Renamed `sales_page_page_type` and `sales_page_page_url` properties, respectively to `sales_page_type` and `sales_page_url` according to the specs.
- *                     Add missing quotes in enrollment/access default messages shortcodes.
+ *                     Added missing quotes in enrollment/access default messages shortcodes.
+ *                     Added `rest_taxonomies` property.
  * @version [version]
  *
  * @todo update tests to check links.
@@ -32,6 +33,18 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 	 * @var string
 	 */
 	protected $post_type = 'course';
+
+	/**
+	 * Taxonomies shown in rest.
+	 *
+	 * @var string[]
+	 */
+	protected $rest_taxonomies = array(
+		'course_cat',
+		'course_difficulty',
+		'course_tag',
+		'course_track',
+	);
 
 	/**
 	 *
@@ -1297,7 +1310,6 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 		$this->assertEquals( 401, $response->get_status() );
 
 	}
-
 
 	/**
 	 * Test list course content.


### PR DESCRIPTION
fix #109