### PR TITLE
Remove non-existing membership taxonomies from response samples

### DIFF
--- a/spec/components/schemas/MembershipResponse.yaml
+++ b/spec/components/schemas/MembershipResponse.yaml
@@ -105,14 +105,6 @@ allOf:
               {
                 "taxonomy": "membership_tag",
                 "href": "/wp-json/wp-v2/membership_tag?post=123"
-              },
-              {
-                "taxonomy": "membership_difficulty",
-                "href": "/wp-json/wp-v2/membership_difficulty?post=123"
-              },
-              {
-                "taxonomy": "membership_track",
-                "href": "/wp-json/wp-v2/membership_track?post=123"
               }
             ]
             items:


### PR DESCRIPTION
fix #111