### PR TITLE
Clean up post_type property in spec.

### DIFF
--- a/spec/components/parameters/PostType.yaml
+++ b/spec/components/parameters/PostType.yaml
@@ -3,4 +3,12 @@ in: query
 description: Filter results to those of a specific `post_type`.
 required: false
 schema:
-  $ref: '#/components/schemas/PostType'
+  type: string
+  enum:
+    - course
+    - lesson
+    - llms_membership
+    - llms_question
+    - llms_quiz
+    - section
+  default: course

--- a/spec/components/schemas/Membership.yaml
+++ b/spec/components/schemas/Membership.yaml
@@ -10,7 +10,7 @@ allOf:
       permalink:
         example: https://example.com/membership/getting-started-with-lifterlms
       post_type:
-        default: membership
+        default: llms_membership
         type: string
       categories:
         description: List of membership categories.

--- a/spec/components/schemas/PostPublic.yaml
+++ b/spec/components/schemas/PostPublic.yaml
@@ -13,9 +13,7 @@ allOf:
         example: https://example.com/post/getting-started-with-lifterlms
         readOnly: true
       post_type:
-        allOf:
-          - $ref: '#/components/schemas/PostType'
-          - readOnly: true
+          $ref: '#/components/schemas/PostType'
       status:
         $ref: '#/components/schemas/PostStatus'
       password:

--- a/spec/components/schemas/PostType.yaml
+++ b/spec/components/schemas/PostType.yaml
@@ -1,7 +1,3 @@
-description: LifterLMS custom post types available for enrollments
+description: LifterLMS custom post type.
 type: string
-enum:
-  - course
-  - llms_membership
-  - section
-default: course
+readOnly: true

--- a/spec/components/schemas/Quiz.yaml
+++ b/spec/components/schemas/Quiz.yaml
@@ -36,9 +36,8 @@ properties:
   post_type:
     allOf:
       - $ref: '#/components/schemas/PostType'
-      - readOnly: true
-        type: string
-        default: llms_quiz
+    type: string
+    default: llms_quiz
   status:
     description: The publication status of the quiz.
     type: string

--- a/spec/components/schemas/QuizQuestion.yaml
+++ b/spec/components/schemas/QuizQuestion.yaml
@@ -27,9 +27,8 @@ properties:
   post_type:
     allOf:
       - $ref: '#/components/schemas/PostType'
-      - readOnly: true
-        type: string
-        default: llms_question
+    type: string
+    default: llms_question
   order:
     description: Order of the question within its immediate parent.
     type: integer

--- a/spec/components/schemas/Section.yaml
+++ b/spec/components/schemas/Section.yaml
@@ -37,7 +37,5 @@ properties:
   post_type:
     allOf:
       - $ref: '#/components/schemas/PostType'
-      - type: string
-        default: section
-        readOnly: true
-
+    type: string
+    default: section


### PR DESCRIPTION
* Move `default` from `#/components/schemas/PostType` to `#/components/schemas/parameters/PostType`.
* Move `enum` from `#/components/schemas/PostType` to `#/components/schemas/parameters/PostType`.
* Add `lesson`, `llms_question` and `llms_quiz` to enum.
* Move `readOnly` from `#/components/schemas/PostPublic` and object schemas to `#/components/schemas/PostType`.
* Corrected indentation of fields in property schema when used with `allOf`. This caused ReDoc to not use `default` on the `post_type` property of the `section` object.
* Remove enrollment mention from `description`.
* Fix `post_type` default value.

### Before and After
![post_type_course](https://user-images.githubusercontent.com/5377968/67153491-0a26ed80-f2b0-11e9-94fe-4304a323f438.png)

![post_type_section](https://user-images.githubusercontent.com/5377968/67153492-1612af80-f2b0-11e9-9a67-a162bbba6acc.png)

![post_type_lesson](https://user-images.githubusercontent.com/5377968/67153493-1d39bd80-f2b0-11e9-9664-a82f90941bd4.png)

![post_type_membership](https://user-images.githubusercontent.com/5377968/67153496-22970800-f2b0-11e9-82d2-69c5e0bd2835.png)

`npm test` was run and  passed validation.