### PR TITLE
Initialize returned array.

### DIFF
--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -885,6 +885,8 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 */
 	protected function prepare_item_for_database( $request ) {
 
+		$prepared_item = [];
+
 		// LLMS Post ID.
 		if ( isset( $request['id'] ) ) {
 			$existing_object = $this->get_object( absint( $request['id'] ) );

--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -885,7 +885,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 */
 	protected function prepare_item_for_database( $request ) {
 
-		$prepared_item = [];
+		$prepared_item = array();
 
 		// LLMS Post ID.
 		if ( isset( $request['id'] ) ) {


### PR DESCRIPTION
Fix issue where null could be returned instead of an empty array if all of the `if` conditions evaluate to false.