### PR TITLE
Make sure to fire proper filter hooks when retrieving the list of filters to remove for response.

### DIFF
--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -28,6 +28,8 @@ defined( 'ABSPATH' ) || exit;
  *                     Initialize `$prepared_item` array before adding values to it.
  * @since [version] Implemented a generic way to create and get an llms post object instance given a `post_type`.
  *                     In `get_objects_from_query()` avoid performing an additional query, just return the already retrieved posts.
+ *                     Removed `"llms_rest_{$this->post_type}_filters_removed_for_reponse"` filter hooks,
+ *                     `"llms_rest_{$this->post_type}_filters_removed_for_response"` added.
  */
 abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 
@@ -1367,6 +1369,8 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 * Get action/filters to be removed before preparing the item for response.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Removed `"llms_rest_{$this->post_type}_filters_removed_for_reponse"` filter hooks,
+	 *                     `"llms_rest_{$this->post_type}_filters_removed_for_response"` added.
 	 *
 	 * @param LLMS_Post_Model $object LLMS_Post_Model object.
 	 * @return array Array of action/filters to be removed for response.
@@ -1376,12 +1380,14 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 		/**
 		 * Modify the array of filters to be removed before building the response.
 		 *
-		 * @since 1.0.0-beta.1
+		 * The dynamic portion of the hook name, `$this->post_type`, refers to the post type slug.
+		 *
+		 * @since [version]
 		 *
 		 * @param array           $filters Array of filters to be removed.
 		 * @param LLMS_Post_Model $object  LLMS_Post_Model object.
 		 */
-		return apply_filters( "llms_rest_{$this->post_type}_filters_removed_for_reponse", array(), $object );
+		return apply_filters( "llms_rest_{$this->post_type}_filters_removed_for_response", array(), $object );
 
 	}
 

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Courses Controller Class.
+ * REST Courses Controller.
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Courses_Controller.
+ * LLMS_REST_Courses_Controller class.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 Make `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Courses Controller Class
+ * REST Courses Controller Class.
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Courses_Controller
+ * LLMS_REST_Courses_Controller.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 Make `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.
@@ -36,11 +36,12 @@ defined( 'ABSPATH' ) || exit;
  *                     Call `set_bulk()` llms post method passing `true` as second parameter, so to instruct it to return a WP_Error on failure.
  *                     Add missing quotes in enrollment/access default messages shortcodes.
  *                     `sales_page_page_id` and `sales_page_url` always returned in edit context.
- * @since [version] Removed `create_llms_post()` and `get_object()` methods, now abstracted in `LLMS_REST_Posts_Controller` class.
  * @since [version] In `update_additional_object_fields()` method, use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
  *                     Also made sure course's `instructor` is at least set as the post author.
  *                     Defined `instructors` validate callback so to make sure instructors list is either not empty and composed by real user ids.
  *                     Fixed `sales_page_url` not returned in `edit` context.
+ *                     Removed `create_llms_post()` and `get_object()` methods, now abstracted in `LLMS_REST_Posts_Controller` class.
+ *                     `llms_rest_course_filters_removed_for_response` filter hook added.
  */
 class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
@@ -989,70 +990,82 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 * Get action/filters to be removed before preparing the item for response.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] `llms_rest_course_filters_removed_for_response` filter hook added.
 	 *
 	 * @param LLMS_Course $course Course object.
 	 * @return array Array of action/filters to be removed for response.
 	 */
 	protected function get_filters_to_be_removed_for_response( $course ) {
 
-		if ( ! llms_blocks_is_post_migrated( $course->get( 'id' ) ) ) {
-			return array();
+		$filters = array();
+
+		if ( llms_blocks_is_post_migrated( $course->get( 'id' ) ) ) {
+			$filters = array(
+				// hook => [callback, priority].
+				'lifterlms_single_course_after_summary' => array(
+					// Course Information.
+					array(
+						'callback' => 'lifterlms_template_single_meta_wrapper_start',
+						'priority' => 5,
+					),
+					array(
+						'callback' => 'lifterlms_template_single_length',
+						'priority' => 10,
+					),
+					array(
+						'callback' => 'lifterlms_template_single_difficulty',
+						'priority' => 20,
+					),
+					array(
+						'callback' => 'lifterlms_template_single_course_tracks',
+						'priority' => 25,
+					),
+					array(
+						'callback' => 'lifterlms_template_single_course_categories',
+						'priority' => 30,
+					),
+					array(
+						'callback' => 'lifterlms_template_single_course_tags',
+						'priority' => 35,
+					),
+					array(
+						'callback' => 'lifterlms_template_single_meta_wrapper_end',
+						'priority' => 50,
+					),
+					// Course Progress.
+					array(
+						'callback' => 'lifterlms_template_single_course_progress',
+						'priority' => 60,
+					),
+					// Course Syllabus.
+					array(
+						'callback' => 'lifterlms_template_single_syllabus',
+						'priority' => 90,
+					),
+					// Instructors.
+					array(
+						'callback' => 'lifterlms_template_course_author',
+						'priority' => 40,
+					),
+					// Pricing Table.
+					array(
+						'callback' => 'lifterlms_template_pricing_table',
+						'priority' => 60,
+					),
+				),
+			);
 		}
 
-		return array(
-			// hook => [callback, priority].
-			'lifterlms_single_course_after_summary' => array(
-				// Course Information.
-				array(
-					'callback' => 'lifterlms_template_single_meta_wrapper_start',
-					'priority' => 5,
-				),
-				array(
-					'callback' => 'lifterlms_template_single_length',
-					'priority' => 10,
-				),
-				array(
-					'callback' => 'lifterlms_template_single_difficulty',
-					'priority' => 20,
-				),
-				array(
-					'callback' => 'lifterlms_template_single_course_tracks',
-					'priority' => 25,
-				),
-				array(
-					'callback' => 'lifterlms_template_single_course_categories',
-					'priority' => 30,
-				),
-				array(
-					'callback' => 'lifterlms_template_single_course_tags',
-					'priority' => 35,
-				),
-				array(
-					'callback' => 'lifterlms_template_single_meta_wrapper_end',
-					'priority' => 50,
-				),
-				// Course Progress.
-				array(
-					'callback' => 'lifterlms_template_single_course_progress',
-					'priority' => 60,
-				),
-				// Course Syllabus.
-				array(
-					'callback' => 'lifterlms_template_single_syllabus',
-					'priority' => 90,
-				),
-				// Instructors.
-				array(
-					'callback' => 'lifterlms_template_course_author',
-					'priority' => 40,
-				),
-				// Pricing Table.
-				array(
-					'callback' => 'lifterlms_template_pricing_table',
-					'priority' => 60,
-				),
-			),
-		);
+		/**
+		 * Modify the array of filters to be removed before building the response.
+		 *
+		 * @since [version]
+		 *
+		 * @param array       $filters Array of filters to be removed.
+		 * @param LLMS_Course $course  Course object.
+		 */
+		return apply_filters( 'llms_rest_course_filters_removed_for_response', $filters, $course );
+
 	}
 
 	/**

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -42,6 +42,7 @@ defined( 'ABSPATH' ) || exit;
  *                     Fixed `sales_page_url` not returned in `edit` context.
  *                     Removed `create_llms_post()` and `get_object()` methods, now abstracted in `LLMS_REST_Posts_Controller` class.
  *                     `llms_rest_course_filters_removed_for_response` filter hook added.
+ *                     Added `llms_rest_course_item_schema`, `llms_rest_pre_insert_course`, `llms_rest_prepare_course_object_response`, `llms_rest_course_links` filter hooks.
  */
 class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
@@ -162,7 +163,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 * @since 1.0.0-beta.8 Renamed `sales_page_page_type` and `sales_page_page_url` properties, respectively to `sales_page_type` and `sales_page_url` according to the specs.
 	 *                     Add missing quotes in enrollment/access default messages shortcodes.
 	 * @since [version] Make sure instructors list is either not empty and composed by real user ids.
-	 *
+	 *                     Added `llms_rest_course_item_schema` filter hook.
 	 * @return array
 	 */
 	public function get_item_schema() {
@@ -515,7 +516,14 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
 		$schema['properties'] = array_merge( (array) $schema['properties'], $course_properties );
 
-		return $schema;
+		/**
+		 * Filter item schema for the course controller.
+		 *
+		 * @since [version]
+		 *
+		 * @param array $schema Item schema data.
+		 */
+		return apply_filters( 'llms_rest_course_item_schema', $schema );
 
 	}
 
@@ -527,6 +535,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 *                     Also Renamed `sales_page_page_type` and `sales_page_page_url` properties, respectively to `sales_page_type` and `sales_page_url` according to the specs.
 	 *                     Always return `sales_page_url` and `sales_page_page_id` when in `edit` context.
 	 * @since [version] Fixed `sales_page_url` not returned in `edit` context.
+	 *                     Added `llms_rest_prepare_course_object_response` filter hook.
 	 *
 	 * @param LLMS_Course     $course  Course object.
 	 * @param WP_REST_Request $request Full details about the request.
@@ -648,7 +657,16 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			$data['sales_page_url'] = $course->get( 'sales_page_content_url' );
 		}
 
-		return $data;
+		/**
+		 * Filters the course data for a response.
+		 *
+		 * @since [version]
+		 *
+		 * @param array           $data    Array of course properties prepared for response.
+		 * @param LLMS_Course     $course  Course object.
+		 * @param WP_REST_Request $request Full details about the request.
+		 */
+		return apply_filters( 'llms_rest_prepare_course_object_response', $data, $course, $request );
 
 	}
 
@@ -663,6 +681,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 *                     which the consumer cannot avoid having no direct control on those properties.
 	 *                     Made `access_opens_date`, `access_closes_date`, `enrollment_opens_date`, `enrollment_closes_date` nullable.
 	 * @since 1.0.0-beta.8 Renamed `sales_page_page_type` and `sales_page_page_url` properties, respectively to `sales_page_type` and `sales_page_url` according to the specs.
+	 * @since [version] Added `llms_rest_pre_insert_course` filter hook.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return array|WP_Error Array of llms post args or WP_Error.
@@ -742,7 +761,16 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			$prepared_item['sales_page_content_url'] = $request['sales_page_url'];
 		}
 
-		return $prepared_item;
+		/**
+		 * Filters the course data for a response.
+		 *
+		 * @since [version]
+		 *
+		 * @param array           $prepared_item Array of course item properties prepared for database.
+		 * @param WP_REST_Request $request       Full details about the request.
+		 * @param array           $schema        The item schema.
+		 */
+		return apply_filters( 'llms_rest_pre_insert_course', $prepared_item, $request, $schema );
 
 	}
 
@@ -1071,7 +1099,10 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	/**
 	 * Prepare links for the request.
 	 *
-	 * @param LLMS_Course $course  LLMS Course.
+	 * @since 1.0.0-beta.1
+	 * @since [version] Added `llms_rest_course_links` filter hook.
+	 *
+	 * @param LLMS_Course $course LLMS Course.
 	 * @return array Links for the given object.
 	 */
 	protected function prepare_links( $course ) {
@@ -1130,7 +1161,17 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			),
 		);
 
-		return array_merge( $links, $course_links );
+		$links = array_merge( $links, $course_links );
+
+		/**
+		 * Filters the courses's links.
+		 *
+		 * @since [version]
+		 *
+		 * @param array       $links  Links for the given lesson.
+		 * @param LLMS_Course $course Course object.
+		 */
+		return apply_filters( 'llms_rest_course_links', $links, $course );
 	}
 
 	/**

--- a/includes/server/class-llms-rest-enrollments-controller.php
+++ b/includes/server/class-llms-rest-enrollments-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Enrollments Controller Class
+ * REST Enrollments Controller.
  *
  * @package LLMS_REST
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Enrollments_Controller
+ * LLMS_REST_Enrollments_Controller class.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.3 Don't output "Last" page link header on the last page.

--- a/includes/server/class-llms-rest-instructors-controller.php
+++ b/includes/server/class-llms-rest-instructors-controller.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Instructors_Controller class..
+ * LLMS_REST_Instructors_Controller class.
  *
  * @since 1.0.0-beta.1
  */

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Lessons Controller Class.
+ * REST Lessons Controller.
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 
 /**
- * LLMS_REST_Lessons_Controller.
+ * LLMS_REST_Lessons_Controller class.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 `prepare_objects_query()` renamed to `prepare_collection_query_args()`.

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -758,7 +758,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		 *
 		 * @since 1.0.0-beta.7
 		 *
-		 * @param array       links   Links for the given lesson.
+		 * @param array       $links  Links for the given lesson.
 		 * @param LLMS_Lesson $lesson Lesson object.
 		 */
 		return apply_filters( 'llms_rest_lesson_links', $links, $lesson );

--- a/includes/server/class-llms-rest-memberships-controller.php
+++ b/includes/server/class-llms-rest-memberships-controller.php
@@ -79,20 +79,31 @@ class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
 	 * @return array Array of action/filters to be removed for response.
 	 */
 	protected function get_filters_to_be_removed_for_response( $membership ) {
-		if ( ! llms_blocks_is_post_migrated( $membership->get( 'id' ) ) ) {
-			return array();
+
+		$filters = array();
+
+		if ( llms_blocks_is_post_migrated( $membership->get( 'id' ) ) ) {
+			$filters = array(
+				// hook => [callback, priority].
+				'lifterlms_single_membership_after_summary' => array(
+					// Membership Information.
+					array(
+						'callback' => 'lifterlms_template_pricing_table',
+						'priority' => 10,
+					),
+				),
+			);
 		}
 
-		return array(
-			// hook => [callback, priority].
-			'lifterlms_single_membership_after_summary' => array(
-				// Membership Information.
-				array(
-					'callback' => 'lifterlms_template_pricing_table',
-					'priority' => 10,
-				),
-			),
-		);
+		/**
+		 * Modify the array of filters to be removed before building the response.
+		 *
+		 * @since [version]
+		 *
+		 * @param array           $filters    Array of filters to be removed.
+		 * @param LLMS_Membership $membership Membership object.
+		 */
+		return apply_filters( 'llms_rest_llms_membership_filters_removed_for_response', $filters, $membership );
 	}
 
 	/**

--- a/includes/server/class-llms-rest-memberships-controller.php
+++ b/includes/server/class-llms-rest-memberships-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Memberships Controller Class
+ * REST Memberships Controller.
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Memberships_Controller.
+ * LLMS_REST_Memberships_Controller class.
  *
  * @since [version]
  */

--- a/includes/server/class-llms-rest-sections-controller.php
+++ b/includes/server/class-llms-rest-sections-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Sections Controller Class
+ * REST Sections Controller-
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 
 /**
- * LLMS_REST_Sections_Controller
+ * LLMS_REST_Sections_Controller class.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 `prepare_objects_query()` renamed to `prepare_collection_query_args()`.

--- a/includes/server/class-llms-rest-students-controller.php
+++ b/includes/server/class-llms-rest-students-controller.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Students_Controller class..
+ * LLMS_REST_Students_Controller class.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 Added `prepare_args_for_total_count_query()` method override.

--- a/includes/server/class-llms-rest-students-progress-controller.php
+++ b/includes/server/class-llms-rest-students-progress-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST Controller for Student Progress
+ * REST Controller for Student Progress.
  *
  * @package  LifterLMS_REST/Classes
  *


### PR DESCRIPTION
fixes #139 
Also added `llms_rest_course_item_schema`, `llms_rest_pre_insert_course`, `llms_rest_prepare_course_object_response`, `llms_rest_course_links` filter hooks for the courses resource.