### PR TITLE
Fix 'content' query parameter schema.

### DIFF
--- a/includes/server/class-llms-rest-enrollments-controller.php
+++ b/includes/server/class-llms-rest-enrollments-controller.php
@@ -34,6 +34,7 @@ defined( 'ABSPATH' ) || exit;
  *                     Added `llms_rest_enrollents_item_schema`, `llms_rest_prepare_enrollment_object_response`,
  *                     `llms_rest_enrollment_links` filter hooks.
  *                     Also fix return when the enrollment to be deleted doesn't exist.
+ * @since [version] Fixed 'context' query parameter schema.
  */
 class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 
@@ -618,6 +619,7 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 	 * Build the query params for the objects collection.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed 'context' query parameter schema.
 	 *
 	 * @return array Collection parameters.
 	 */
@@ -640,7 +642,7 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$query_params['context'] = 'view';
+		$query_params['context']['default'] = 'view';
 
 		return $query_params;
 	}

--- a/includes/server/class-llms-rest-enrollments-controller.php
+++ b/includes/server/class-llms-rest-enrollments-controller.php
@@ -642,8 +642,6 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$query_params['context']['default'] = 'view';
-
 		return $query_params;
 	}
 


### PR DESCRIPTION
A query parameter schema should be an array. LLMS_REST_Controller->get_collection_params() is a good example of how 'context' should be defined.