### PR TITLE
Fixed pagination test taking into account post revisions.

### DIFF
--- a/tests/unit-tests/server/class-llms-rest-test-enrollments.php
+++ b/tests/unit-tests/server/class-llms-rest-test-enrollments.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for Enrollments API.
+ * Tests for Enrollments API
  *
  * @package LifterLMS_Rest/Tests
  *
@@ -10,7 +10,7 @@
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 Added links test.
  * @since 1.0.0-beta.10 Added test on the trigger property/param.
- * @version 1.0.0-beta.10
+ * @since [version] Fixed pagination test taking into account course post revisions.
  */
 class LLMS_REST_Test_Enrollments extends LLMS_REST_Unit_Test_Case_Server {
 
@@ -119,6 +119,7 @@ class LLMS_REST_Test_Enrollments extends LLMS_REST_Unit_Test_Case_Server {
 	 * Test list student enrollments pagination.
 	 *
 	 * @since 1.0.0-beta.3
+	 * @since [version] Fixed pagination test taking into account course post revisions.
 	 */
 	public function test_get_enrollments_pagination() {
 
@@ -138,8 +139,7 @@ class LLMS_REST_Test_Enrollments extends LLMS_REST_Unit_Test_Case_Server {
 
 		$route = $this->parse_route( $user_id );
 
-		$this->pagination_test( $route, $start_course_id, 10, 'post_id' );
-
+		$this->pagination_test( $route, $start_course_id, 10, 'post_id', $total = 25, $ids_step = 2 );
 	}
 
 	/**

--- a/tests/unit-tests/server/class-llms-rest-test-memberships.php
+++ b/tests/unit-tests/server/class-llms-rest-test-memberships.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for Memberships API.
+ * Tests for Memberships API
  *
  * @package LifterLMS_Rest/Tests/Controllers
  *
@@ -8,11 +8,12 @@
  * @group rest_memberships
  *
  * @since 1.0.0-beta.9
- * @version 1.0.0-beta.9
+ * @since [version] Fixed `post_type` property.
  *
  * @todo do more tests on the membership update/delete.
  */
 class LLMS_REST_Test_Memberships extends LLMS_REST_Unit_Test_Case_Posts {
+
 	/**
 	 * Default restriction message.
 	 *
@@ -28,7 +29,7 @@ class LLMS_REST_Test_Memberships extends LLMS_REST_Unit_Test_Case_Posts {
 	 *
 	 * @var string
 	 */
-	protected $post_type = 'membership';
+	protected $post_type = 'llms_membership';
 
 	/**
 	 * Route.


### PR DESCRIPTION
## Description
Since the introduction of the revisions for certain llms post types the pagination tests failed, as they relied on the fact that subsequent posts had progressive ids with step=1,

## How has this been tested?
unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

