### PR TITLE
Fix infinite loop when providing a correct key but incorrect secret

### DIFF
--- a/includes/class-llms-rest-authentication.php
+++ b/includes/class-llms-rest-authentication.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.5
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.5 is_rest_request() accesses uses `filter_var` instead of `llms_filter_input()`.
  *                     Load all includes to accommodate plugins and themes that call `determine_current_user` early.
+ * @since [version] Call `llms_rest_authorization_required_error()` instructing to not check if the current user is logged in
+ *                      to avoid infinite loops.
  */
 class LLMS_REST_Authentication {
 
@@ -62,6 +64,8 @@ class LLMS_REST_Authentication {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.5 Load all includes to accommodate plugins and themes that call `determine_current_user` early.
+	 * @since [version] Call `llms_rest_authorization_required_error()` instructing to not check if the current user is logged in
+	 *                      to avoid infinite loops.
 	 *
 	 * @link https://developer.wordpress.org/reference/hooks/determine_current_user/
 	 *
@@ -91,7 +95,7 @@ class LLMS_REST_Authentication {
 		}
 
 		if ( ! hash_equals( $key->get( 'consumer_secret' ), $creds['secret'] ) ) {
-			$this->set_error( llms_rest_authorization_required_error() );
+			$this->set_error( llms_rest_authorization_required_error( '', false ) );
 			return false;
 		}
 
@@ -128,6 +132,10 @@ class LLMS_REST_Authentication {
 	/**
 	 * Check if the API Key can perform the request.
 	 *
+	 * @since 1.0.0-beta.1
+	 * @since [version] Call `llms_rest_authorization_required_error()` instructing to not check if the current user is logged in
+	 *                      to avoid infinite loops.
+	 *
 	 * @param mixed           $result  Response to replace the requested version with.
 	 * @param WP_REST_Server  $server  Server instance.
 	 * @param WP_REST_Request $request Request used to generate the response.
@@ -139,7 +147,7 @@ class LLMS_REST_Authentication {
 
 			$allowed = $this->api_key->has_permission( $request->get_method() );
 			if ( ! $allowed ) {
-				return llms_rest_authorization_required_error();
+				return llms_rest_authorization_required_error( '', false );
 			}
 
 			// Update the API key's last access time.

--- a/includes/server/llms-rest-server-functions.php
+++ b/includes/server/llms-rest-server-functions.php
@@ -1,46 +1,41 @@
 <?php
 /**
- * REST Server functions.
+ * REST Server functions
  *
  * @package LifterLMS_REST/Functions
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * REST Server functions.
- *
- * @package LifterLMS_REST/Functions
- *
- * @since 1.0.0-beta.1
- * @since 1.0.0-beta.9 Added an util to validate a list of instructors.
- */
-
-/**
  * Return a WP_Error with proper code, message and status for unauthorized requests.
  *
  * @since 1.0.0-beta.1
+ * @since [version] Added a second paramater to avoid checking if the user is logged in.
  *
- * @param string $message Optional. The custom error message. Default empty string.
- *                        When no custom message is provided a predefined message will be used.
+ * @param string  $message             Optional. The custom error message. Default empty string.
+ *                                     When no custom message is provided a predefined message will be used.
+ * @param boolean $check_authenticated Optional. Whether or not checking if the current user is logged in. Default `true`.
  * @return WP_Error
  */
-function llms_rest_authorization_required_error( $message = '' ) {
-	if ( is_user_logged_in() ) {
+function llms_rest_authorization_required_error( $message = '', $check_authenticated = true ) {
+	if ( $check_authenticated && is_user_logged_in() ) {
 		// 403.
 		$error_code = 'llms_rest_forbidden_request';
 		$_message   = __( 'You are not authorized to perform this request.', 'lifterlms' );
+		$status     = '403';
 	} else {
 		// 401.
 		$error_code = 'llms_rest_unauthorized_request';
 		$_message   = __( 'The API credentials were invalid.', 'lifterlms' );
+		$status     = '401';
 	}
 
 	$message = ! $message ? $_message : $message;
-	return new WP_Error( $error_code, $message, array( 'status' => rest_authorization_required_code() ) );
+	return new WP_Error( $error_code, $message, array( 'status' => $status ) );
 }
 
 /**

--- a/tests/unit-tests/class-llms-rest-test-authentication.php
+++ b/tests/unit-tests/class-llms-rest-test-authentication.php
@@ -2,12 +2,13 @@
 /**
  * Test authentication methods.
  *
- * @package  LifterLMS_REST/Tests
+ * @package LifterLMS_REST/Tests
  *
  * @group auth
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @since [version] Unset the global `current_user` where needed to catch possibile infinite loops on authentication error.
+ * @version [version]
  */
 class LLMS_REST_Test_Authentication extends LLMS_REST_Unit_Test_Case_Base {
 
@@ -23,6 +24,7 @@ class LLMS_REST_Test_Authentication extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test the authenticate method.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Unset the global `current_user` where needed to catch possibile infinite loops on authentication error.
 	 *
 	 * @return void
 	 */
@@ -62,6 +64,7 @@ class LLMS_REST_Test_Authentication extends LLMS_REST_Unit_Test_Case_Base {
 		$this->assertEquals( $expected_actions, did_action( 'llms_rest_basic_auth_success' ) );
 
 		// Correct key, incorrect secret.
+		unset($GLOBALS['current_user']); // Make sure the current user is not set: e.g. to catch possibile infinite loops on authentication error.
 		$_SERVER['HTTP_X_LLMS_CONSUMER_SECRET'] = 'fakesecret';
 		$this->assertEquals( false, $this->auth->authenticate( false ) );
 		$this->assertEquals( $expected_actions, did_action( 'llms_rest_basic_auth_success' ) );

--- a/tests/unit-tests/server/class-llms-rest-test-server-functions.php
+++ b/tests/unit-tests/server/class-llms-rest-test-server-functions.php
@@ -8,7 +8,8 @@
  * @group rest_functions
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @since [versuib] Test the llms_rest_authorization_required_error() function `$check_authenticated` parameter.
+ * @version [version]
  */
 class LLMS_REST_Test_Server_Functions extends LLMS_REST_Unit_Test_Case_Server {
 
@@ -60,6 +61,48 @@ class LLMS_REST_Test_Server_Functions extends LLMS_REST_Unit_Test_Case_Server {
 		$this->assertIsWPError( $err );
 		$this->assertWPErrorCodeEquals( 'llms_rest_forbidden_request', $err );
 		$this->assertWPErrorDataEquals( array( 'status' => 403 ), $err );
+		$this->assertWPErrorMessageEquals( 'My message.', $err );
+
+	}
+
+	/**
+	 * Test the llms_rest_authorization_required_error() function `$check_authenticated` parameter.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_rest_authorization_required_error_with_check_authenticated_false() {
+
+		// Default.
+		$err = llms_rest_authorization_required_error('', false);
+		$this->assertIsWPError( $err );
+		$this->assertWPErrorCodeEquals( 'llms_rest_unauthorized_request', $err );
+		$this->assertWPErrorDataEquals( array( 'status' => 401 ), $err );
+		$this->assertWPErrorMessageEquals( 'The API credentials were invalid.', $err );
+
+		//  Custom message.
+		$err = llms_rest_authorization_required_error( 'My message.', false );
+		$this->assertIsWPError( $err );
+		$this->assertWPErrorCodeEquals( 'llms_rest_unauthorized_request', $err );
+		$this->assertWPErrorDataEquals( array( 'status' => 401 ), $err );
+		$this->assertWPErrorMessageEquals( 'My message.', $err );
+
+		// Log in.
+		wp_set_current_user( $this->factory->user->create() );
+
+		// Default.
+		$err = llms_rest_authorization_required_error('', false);
+		$this->assertIsWPError( $err );
+		$this->assertWPErrorCodeEquals( 'llms_rest_unauthorized_request', $err );
+		$this->assertWPErrorDataEquals( array( 'status' => 401 ), $err );
+		$this->assertWPErrorMessageEquals( 'The API credentials were invalid.', $err );
+
+		//  Custom message.
+		$err = llms_rest_authorization_required_error( 'My message.', false );
+		$this->assertIsWPError( $err );
+		$this->assertWPErrorCodeEquals( 'llms_rest_unauthorized_request', $err );
+		$this->assertWPErrorDataEquals( array( 'status' => 401 ), $err );
 		$this->assertWPErrorMessageEquals( 'My message.', $err );
 
 	}


### PR DESCRIPTION
## Description
Fixes #158 

## How has this been tested?
Old and new unit tests.
I've added tests on the new parameter added for the function `llms_rest_authorization_required_error()`.
And I've also changed an existing test (`LLMS_REST_Test_Authentication::test_authenticate()`) in order to allow the infinite loop to occur: I've tested this particular one before applying the patch.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

