### PR TITLE
Update spec to state context requirements for user information fields

### DIFF
--- a/spec/components/schemas/Instructor.yaml
+++ b/spec/components/schemas/Instructor.yaml
@@ -8,7 +8,10 @@ allOf:
   - type: object
     properties:
       roles:
-        description: The user's WordPress user role.
+        description: |
+          The user's WordPress user role.
+
+          Only returned when `context=edit`.
         type: array
         default: [ instructor ]
         items:

--- a/spec/components/schemas/Student.yaml
+++ b/spec/components/schemas/Student.yaml
@@ -8,7 +8,10 @@ allOf:
   - type: object
     properties:
       roles:
-        description: The user's WordPress user role.
+        description: |
+          The user's WordPress user role.
+
+          Only returned when `context=edit`.
         type: array
         default: [ student ]
         items:

--- a/spec/components/schemas/User.yaml
+++ b/spec/components/schemas/User.yaml
@@ -7,11 +7,17 @@ properties:
       - description: Unique User Identifer. The WordPress User `ID`.
         example: 456
   email:
-    description: The user's email address.
+    description: |
+      The user's email address.
+
+      Only returned when `context=edit`.
     type: string
     example: jamie@lifterlms.com
   username:
-    description: The user's username.
+    description: |
+      The user's username.
+
+      Only returned when `context=edit`.
     type: string
     example: jamie2019
   password:
@@ -24,7 +30,10 @@ properties:
     type: string
     example: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   registered_date:
-    description: The user's original site registration date.
+    description: |
+      The user's original site registration date.
+
+      Only returned when `context=edit`.
     type: string
     example: '2019-05-03 19:25:01'
   avatar_urls:
@@ -49,15 +58,24 @@ properties:
     type: string
     example: https://myawesomewebsite.tld
   first_name:
-    description: The user's first name.
+    description: |
+      The user's first name.
+
+      Only returned when `context=edit`.
     type: string
     example: Jamie
   last_name:
-    description: The user's last name.
+    description: |
+      The user's last name.
+
+      Only returned when `context=edit`.
     type: string
     example: Cook
   nickname:
-    description: The user's chosen nickname.
+    description: |
+      The user's chosen nickname.
+
+      Only returned when `context=edit`.
     type: string
     example: JamieC
   name:
@@ -65,27 +83,45 @@ properties:
     type: string
     example: Jamie Cook
   billing_address_1:
-    description: Address line 1.
+    description: |
+      Address line 1.
+
+      Only returned when `context=edit`.
     type: string
     example: 1234 Somewhere Place
   billing_address_2:
-    description: Address line 2.
+    description: |
+      Address line 2.
+
+      Only returned when `context=edit`.
     type: string
     example: Suite ABC
   billing_city:
-    description: City name.
+    description: |
+      City name.
+
+      Only returned when `context=edit`.
     type: string
     example: Anywhere
   billing_state:
-    description: ISO code or state, province, or district name.
+    description: |
+      ISO code or state, province, or district name.
+
+      Only returned when `context=edit`.
     type: string
     example: CA
   billing_postcode:
-    description: Postal code.
+    description: |
+      Postal code.
+
+      Only returned when `context=edit`.
     type: string
     example: 12345-678
   billing_country:
-    description: ISO country code.
+    description: |
+      ISO country code.
+
+      Only returned when `context=edit`.
     type: string
     example: US
 


### PR DESCRIPTION
This updates the spec to explicitly state when a user information field is only returned in a specific context.

While the OpenAPI 3.0 spec does allow for conditional parameters I cannot get it to work in a way that outputs the information in a readable way via the doc generator.

The solution in this PR is to add the context requirements to the parameter's description. This will not allow examples to be automatically updated (instead examples will return the full information as available in `context=edit`) but it will show in all descriptions (in the main area of the doc browser) when a piece of information is restricted to a particular context.

Instead of adding notes when a piece of information is available in both `view` and `edit`, this adds a note when the information is only available in `context=edit`. If there's no note that means it's returned in all context.

Resolves #143 
