### PR TITLE
fix schema to db key mapping

### DIFF
--- a/includes/abstracts/class-llms-rest-users-controller.php
+++ b/includes/abstracts/class-llms-rest-users-controller.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.10 Fixed setting roles instead of appending them when updating user.
  * @since 1.0.0-beta.11 Correctly map request's `billing_postcode` param to `billing_zip` meta.
  * @since 1.0.0-beta.12 Add `search` and `search_columns` collection filtering.
+ * @since [version] Only add remapped keys to the response when the schema key is present in the expected response fields array.
  */
 abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 
@@ -578,6 +579,7 @@ abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 	 * Prepare an object for response
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Only add remapped keys to the response when the schema key is present in the expected response fields array.
 	 *
 	 * @param LLMS_Abstract_User_Data $object  User object.
 	 * @param WP_REST_Request         $request Request object.
@@ -593,7 +595,9 @@ abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 		unset( $map['user_pass'] );
 
 		foreach ( $map as $db_key => $schema_key ) {
-			$prepared[ $schema_key ] = $object->get( $db_key );
+			if ( in_array( $schema_key, $fields, true ) ) {
+				$prepared[ $schema_key ] = $object->get( $db_key );
+			}
 		}
 
 		if ( in_array( 'roles', $fields, true ) ) {


### PR DESCRIPTION
## Description

I cannot find any issues in the core codebase, nor was able to find a way to write a test to illustrate this issue well so I haven't opened an issue and instead am submitting this PR.

The issue I've found occurs in the Groups add-on where we extend the `LLMS_REST_Students_Controller` to create a stub for the group members controller.

The problem I'm encountering is that response fields are remapped even if they are not expected to be in the response object.

For example, I expect a user object with keys described in the groups member docs at: https://developer.lifterlms.com/rest-api/#tag/Group-Members/paths/~1groups~1{id}~1members/get

You can see the failing tests at https://travis-ci.com/github/gocodebox/lifterlms-groups/jobs/355457738

Once this PR is included into the core rest api you'll see this issue resolved





## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

