### PR TITLE
Prepare links

### DIFF
--- a/includes/abstracts/class-llms-rest-controller.php
+++ b/includes/abstracts/class-llms-rest-controller.php
@@ -626,7 +626,7 @@ abstract class LLMS_REST_Controller extends LLMS_REST_Controller_Stubs {
 	 * @since 1.0.0-beta.1
 	 * @since [version] Added $request parameter.
 	 *
-	 * @param obj             $object Item object.
+	 * @param obj             $object  Item object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */

--- a/includes/abstracts/class-llms-rest-controller.php
+++ b/includes/abstracts/class-llms-rest-controller.php
@@ -626,7 +626,7 @@ abstract class LLMS_REST_Controller extends LLMS_REST_Controller_Stubs {
 	 * @since 1.0.0-beta.1
 	 * @since [version] Added $request parameter.
 	 *
-	 * @param obj $object Item object.
+	 * @param obj             $object Item object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */

--- a/includes/abstracts/class-llms-rest-controller.php
+++ b/includes/abstracts/class-llms-rest-controller.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.12 Added logic to perform a collection search.
  *                      Added `object_inserted()` and `object_completely_inserted()` methods called after an object is
  *                      respectively inserted in the DB and all its additional fields have been updated as well (completely inserted).
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 abstract class LLMS_REST_Controller extends LLMS_REST_Controller_Stubs {
 
@@ -589,7 +590,8 @@ abstract class LLMS_REST_Controller extends LLMS_REST_Controller_Stubs {
 	 * Prepares a single object for response.
 	 *
 	 * @since 1.0.0-beta.1
-	 * @since 1.0.0-beta.3 Return early with a WP_Error if `$object` is a WP_Error
+	 * @since 1.0.0-beta.3 Return early with a WP_Error if `$object` is a WP_Error.
+	 * @since [version] Pass the `$request` parameter to `prepare_links()`.
 	 *
 	 * @param obj             $object Raw object from database.
 	 * @param WP_REST_Request $request Request object.
@@ -612,7 +614,7 @@ abstract class LLMS_REST_Controller extends LLMS_REST_Controller_Stubs {
 		$response = rest_ensure_response( $data );
 
 		// Add links.
-		$response->add_links( $this->prepare_links( $object ) );
+		$response->add_links( $this->prepare_links( $object, $request ) );
 
 		return $response;
 
@@ -622,11 +624,13 @@ abstract class LLMS_REST_Controller extends LLMS_REST_Controller_Stubs {
 	 * Prepare links for the request.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Added $request parameter.
 	 *
 	 * @param obj $object Item object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function prepare_links( $object ) {
+	protected function prepare_links( $object, $request ) {
 
 		$base = rest_url( sprintf( '/%1$s/%2$s', $this->namespace, $this->rest_base ) );
 

--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +33,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.11 Fixed `"llms_rest_insert_{$this->post_type}"` and `"llms_rest_insert_{$this->post_type}"` action hooks fourth param:
  *                     must be false when updating.
  * @since 1.0.0-beta.12 Moved parameters to query args mapping from `$this->prepare_collection_params()` to `$this->map_params_to_query_args()`.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 
@@ -804,6 +805,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 * Prepare a single item for the REST response
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Pass the `$request` parameter to `prepare_links()`.
 	 *
 	 * @param LLMS_Post_Model $object  LLMS post object.
 	 * @param WP_REST_Request $request Request object.
@@ -849,8 +851,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$links = $this->prepare_links( $object );
-		$response->add_links( $links );
+		$response->add_links( $this->prepare_links( $object, $request ) );
 
 		return $response;
 	}
@@ -1276,13 +1277,15 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.7 `self` and `collection` links prepared in the parent class.
 	 *                     Fix wp:featured_media link, we don't expose any embeddable field.
 	 * @since 1.0.0-beta.8 Return links to those taxonomies which have an accessible rest route.
+	 * @since [version] Added $request parameter.
 	 *
 	 * @param LLMS_Post_Model $object  Object data.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given object.
 	 */
-	protected function prepare_links( $object ) {
+	protected function prepare_links( $object, $request ) {
 
-		$links = parent::prepare_links( $object );
+		$links = parent::prepare_links( $object, $request );
 
 		$object_id = $object->get( 'id' );
 

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -467,7 +467,7 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.1
 	 * @since [version] Added $request parameter.
 	 *
-	 * @param LLMS_REST_API_Key $item API Key object.
+	 * @param LLMS_REST_API_Key $item    API Key object.
 	 * @param WP_REST_Request   $request Request object.
 	 * @return array
 	 */

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -468,7 +468,7 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 * @since [version] Added $request parameter.
 	 *
 	 * @param LLMS_REST_API_Key $item API Key object.
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request   $request Request object.
 	 * @return array
 	 */
 	protected function prepare_links( $item, $request ) {

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.7
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 Added: `get_objects_from_query()`, `get_objects_query()`, `get_pagination_data_from_query()`, `prepare_collection_items_for_response()` methods overrides.
  *                  `get_items()` method abstracted and moved in LLMS_REST_Controller.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 
@@ -424,6 +425,7 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 * Prepare an API Key for a REST response.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Pass the `$request` parameter to `prepare_links()`.
 	 *
 	 * @param LLMS_REST_API_Key $item API Key object.
 	 * @param WP_REST_Request   $request Request object.
@@ -453,8 +455,7 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 		$response = rest_ensure_response( $data );
 
 		// Add links.
-		$links = $this->prepare_links( $item );
-		$response->add_links( $links );
+		$response->add_links( $this->prepare_links( $item, $request ) );
 
 		return $response;
 
@@ -464,13 +465,15 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 * Prepare a `_links` object for an API Key.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Added $request parameter.
 	 *
 	 * @param LLMS_REST_API_Key $item API Key object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function prepare_links( $item ) {
+	protected function prepare_links( $item, $request ) {
 
-		$links         = parent::prepare_links( $item );
+		$links         = parent::prepare_links( $item, $request );
 		$links['user'] = array(
 			'href' => rest_url( sprintf( 'wp/v2/users/%d', $item->get( 'user_id' ) ) ),
 		);

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -43,6 +43,7 @@ defined( 'ABSPATH' ) || exit;
  *                     Removed `create_llms_post()` and `get_object()` methods, now abstracted in `LLMS_REST_Posts_Controller` class.
  *                     `llms_rest_course_filters_removed_for_response` filter hook added.
  *                     Added `llms_rest_course_item_schema`, `llms_rest_pre_insert_course`, `llms_rest_prepare_course_object_response`, `llms_rest_course_links` filter hooks.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
@@ -1101,12 +1102,15 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.9 Added `llms_rest_course_links` filter hook.
+	 * @since [version] Added $request parameter.
 	 *
-	 * @param LLMS_Course $course LLMS Course.
+	 * @param LLMS_Course     $course  LLMS Course.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given object.
 	 */
-	protected function prepare_links( $course ) {
-		$links     = parent::prepare_links( $course );
+	protected function prepare_links( $course, $request ) {
+
+		$links     = parent::prepare_links( $course, $request );
 		$course_id = $course->get( 'id' );
 
 		$course_links = array();

--- a/includes/server/class-llms-rest-enrollments-controller.php
+++ b/includes/server/class-llms-rest-enrollments-controller.php
@@ -5,7 +5,7 @@
  * @package LLMS_REST
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -36,6 +36,7 @@ defined( 'ABSPATH' ) || exit;
  *                     Also fix return when the enrollment to be deleted doesn't exist.
  *                     Fixed 'context' query parameter schema.
  * @since 1.0.0-beta.12 Updated `$this->prepare_collection_query_args()` to reflect changes in the parent class.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 
@@ -1030,11 +1031,13 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 	 * Prepare enrollments links for the request.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Added $request parameter.
 	 *
-	 * @param object $enrollment Enrollment object data.
+	 * @param object          $enrollment Enrollment object data.
+	 * @param WP_REST_Request $request    Request object.
 	 * @return array Links for the given object.
 	 */
-	public function prepare_links( $enrollment ) {
+	public function prepare_links( $enrollment, $request ) {
 
 		$links = array(
 			'self'       => array(

--- a/includes/server/class-llms-rest-instructors-controller.php
+++ b/includes/server/class-llms-rest-instructors-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.13 Fixed authentication error messages referring to 'students' or 'users' rather than 'instructors'.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 
@@ -190,13 +191,15 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Added the `$request` parameter.
 	 *
-	 * @param obj $object Item object.
+	 * @param obj             $object  Item object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function prepare_links( $object ) {
+	protected function prepare_links( $object, $request ) {
 
-		$links = parent::prepare_links( $object );
+		$links = parent::prepare_links( $object, $request );
 
 		$links['content'] = array(
 			'href' => sprintf( '%s/content', $links['self']['href'] ),

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -29,6 +29,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.9 Removed `create_llms_post()` and `get_object()` methods, now abstracted in `LLMS_REST_Posts_Controller` class.
  *                     `llms_rest_lesson_filters_removed_for_response` filter hook added.
  * @since 1.0.0-beta.12 Updated `$this->prepare_collection_query_args()` to reflect changes in the parent class.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 
@@ -682,13 +683,15 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	 *                  Fixed `parent` link href, replacing 'section' with 'sections'.
 	 *                  Following links added: `prerequisite`, `quiz`.
 	 *                  Added `llms_rest_lesson_links` filter hook.
+	 * @since [version] Added `$request` parameter.
 	 *
-	 * @param LLMS_Lesson $lesson LLMS Section.
-	 * @return array Links for the given object..
+	 * @param LLMS_Lesson     $lesson  LLMS Section.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given object.
 	 */
-	protected function prepare_links( $lesson ) {
+	protected function prepare_links( $lesson, $request ) {
 
-		$links = parent::prepare_links( $lesson );
+		$links = parent::prepare_links( $lesson, $request );
 
 		unset( $links['content'] );
 

--- a/includes/server/class-llms-rest-memberships-controller.php
+++ b/includes/server/class-llms-rest-memberships-controller.php
@@ -4,8 +4,8 @@
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
- * @since   1.0.0-beta.9
- * @version 1.0.0-beta.9
+ * @since 1.0.0-beta.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,8 +14,10 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_REST_Memberships_Controller class.
  *
  * @since 1.0.0-beta.9
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
+
 	/**
 	 * Enrollments controller.
 	 *
@@ -371,11 +373,16 @@ class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
 	/**
 	 * Prepare links for the request.
 	 *
+	 * @since 1.0.0-beta.9
+	 * @since [version] Added `$request` parameter.
+	 *
 	 * @param LLMS_Membership $membership LLMS Membership.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given object.
 	 */
-	protected function prepare_links( $membership ) {
-		$links = parent::prepare_links( $membership );
+	protected function prepare_links( $membership, $request ) {
+
+		$links = parent::prepare_links( $membership, $request );
 		unset( $links['content'] );
 		$id = $membership->get( 'id' );
 

--- a/includes/server/class-llms-rest-memberships-controller.php
+++ b/includes/server/class-llms-rest-memberships-controller.php
@@ -377,7 +377,7 @@ class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
 	 * @since [version] Added `$request` parameter.
 	 *
 	 * @param LLMS_Membership $membership LLMS Membership.
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request $request    Request object.
 	 * @return array Links for the given object.
 	 */
 	protected function prepare_links( $membership, $request ) {

--- a/includes/server/class-llms-rest-sections-controller.php
+++ b/includes/server/class-llms-rest-sections-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *                     Fix the way we get the section's parent course object when building the resource links.
  * @since 1.0.0-beta.9 Removed `create_llms_post()` and `get_object()` methods, now abstracted in `LLMS_REST_Posts_Controller` class.
  * @since 1.0.0-beta.12 Updated `$this->prepare_collection_query_args()` to reflect changes in the parent class.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 
@@ -405,18 +406,18 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.7 Fix the way we get the section's parent course object.
+	 * @since [version] Added `$request` parameter.
 	 *
-	 * @param LLMS_Section $section  LLMS Section.
+	 * @param LLMS_Section    $section LLMS Section.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given object.
 	 */
-	protected function prepare_links( $section ) {
+	protected function prepare_links( $section, $request ) {
 
-		$links            = parent::prepare_links( $section );
+		$links            = parent::prepare_links( $section, $request );
 		$parent_course_id = $section->get_parent_course();
 
-		/**
-		 * If the section has no course parent return earlier
-		 */
+		// If the section has no course parent return earlier.
 		if ( ! $parent_course_id ) {
 			return $links;
 		}

--- a/includes/server/class-llms-rest-students-controller.php
+++ b/includes/server/class-llms-rest-students-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0-beta.7 Added `prepare_args_for_total_count_query()` method override.
  * @since 1.0.0-beta.12 Added item schema filter.
  *                      Added 'llms_rest_student_registered' action hook - fired after student's creation.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 
@@ -346,13 +347,15 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Added `$request` parameter.
 	 *
-	 * @param obj $object Item object.
+	 * @param obj             $object  Item object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function prepare_links( $object ) {
+	protected function prepare_links( $object, $request ) {
 
-		$links = parent::prepare_links( $object );
+		$links = parent::prepare_links( $object, $request );
 
 		$links['enrollments'] = array(
 			'href' => sprintf( '%s/enrollments', $links['self']['href'] ),

--- a/includes/server/class-llms-rest-students-progress-controller.php
+++ b/includes/server/class-llms-rest-students-progress-controller.php
@@ -344,7 +344,7 @@ class LLMS_REST_Students_Progress_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.1
 	 * @since [version] Added `$request` parameter.
 	 *
-	 * @param obj             $object Item object.
+	 * @param obj             $object  Item object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */

--- a/includes/server/class-llms-rest-students-progress-controller.php
+++ b/includes/server/class-llms-rest-students-progress-controller.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.13
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.13 Fixed student/lesson post meta key to delete when deleting a student progress.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Students_Progress_Controller extends LLMS_REST_Controller {
 
@@ -341,11 +342,13 @@ class LLMS_REST_Students_Progress_Controller extends LLMS_REST_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Added `$request` parameter.
 	 *
-	 * @param obj $object Item object.
+	 * @param obj             $object Item object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function prepare_links( $object ) {
+	protected function prepare_links( $object, $request ) {
 
 		$base = rest_url(
 			sprintf(

--- a/tests/unit-tests/server/class-llms-rest-test-students-controllers.php
+++ b/tests/unit-tests/server/class-llms-rest-test-students-controllers.php
@@ -14,6 +14,7 @@
  * @since 1.0.0-beta.12 Added tests on students search.
  *                      Added tests on firing student registration action hook.
  * @since 1.0.0-beta.13 Fix test failing on WP core 5.0.
+ * @since [version] Update `prepare_links()` to accept a second parameter, `WP_REST_Request`.
  */
 class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Server {
 
@@ -889,13 +890,14 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Serve
 	 * Test the prepare_links method.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Pass second parameter to `prepare_links()`.
 	 *
 	 * @return void
 	 */
 	public function test_prepare_links() {
 
 		$student = $this->factory->student->create_and_get();
-		$links = LLMS_Unit_Test_Util::call_method( $this->endpoint, 'prepare_links', array( $student ) );
+		$links = LLMS_Unit_Test_Util::call_method( $this->endpoint, 'prepare_links', array( $student, new WP_REST_Request() ) );
 		foreach ( array( 'self', 'collection', 'enrollments', 'progress' ) as $rel ) {
 			$this->assertArrayHasKey( $rel, $links );
 		}


### PR DESCRIPTION
## Description

Updates `LLMS_REST_Controller::prepare_links()` to require a second parameter, a `WP_REST_Request`.

Close #175

## How has this been tested?

Existing PHP Unit Tests

## Screenshots <!-- if applicable -->

## Types of changes

This is a backwards incompatible change which will affect any classes which extend the `LLMS_REST_Controller` class **AND** overwrite the `prepare_links()` method.

Overwrite methods will need to update their signature to be compatible with the method in the abstract.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

