### PR TITLE
WIP: 404 in favor of 400 in progress controller

### DIFF
--- a/includes/abstracts/class-llms-rest-users-controller.php
+++ b/includes/abstracts/class-llms-rest-users-controller.php
@@ -214,6 +214,26 @@ abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 	}
 
 	/**
+	 * Retrieves the current user.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_current_item( $request ) {
+
+		$uid = get_current_user_id();
+		if ( empty( $uid ) ) {
+			return llms_rest_authorization_required_error( __( 'You are not logged in.', 'lifterlms' ) );
+		}
+
+		$request['id'] = $uid;
+		return $this->get_item( $request );
+
+	}
+
+	/**
 	 * Retrieve arguments for deleting a resource
 	 *
 	 * @since 1.0.0-beta.1
@@ -609,6 +629,44 @@ abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 		}
 
 		return $prepared;
+
+	}
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 1.0.0-beta.1
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+
+		parent::register_routes();
+
+		// register_rest_route(
+		// 	$this->namespace,
+		// 	'/' . $this->rest_base . '/me',
+		// 	array(
+		// 		array(
+		// 			'methods'             => WP_REST_Server::READABLE,
+		// 			'callback'            => array( $this, 'get_current_item' ),
+		// 			'args'                => $this->get_get_item_params(),
+		// 		),
+		// 		// array(
+		// 		// 	'methods'             => WP_REST_Server::EDITABLE,
+		// 		// 	'callback'            => array( $this, 'update_current_item' ),
+		// 		// 	'permission_callback' => array( $this, 'update_current_item_permissions_check' ),
+		// 		// 	'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ), // see class-wp-rest-controller.php.
+		// 		// ),
+		// 		// array(
+		// 		// 	'methods'             => WP_REST_Server::DELETABLE,
+		// 		// 	'callback'            => array( $this, 'delete_current_item' ),
+		// 		// 	'permission_callback' => array( $this, 'delete_current_item_permissions_check' ),
+		// 		// 	'args'                => $this->get_delete_item_args(),
+		// 		// ),
+		// 		'schema' => array( $this, 'get_public_item_schema' ),
+		// 	)
+		// );
 
 	}
 


### PR DESCRIPTION
This is a early WIP to per #181 

(I named the branch wrong)

@eri-trabiccolo can you have a look through the changes here and see if I'm track per our discussion in #181 

I'm submitting this early because I want to make some progress on this but I'm feeling uncertain whether I'm moving in the right direction.

This still requires the following before it can be submitted as a full PR and merged:

+ [ ] Tests for new server method `llms_rest_page_restricted()`
+ [ ] Logic for GET requests on the progress controller per discussion in #181 
+ [ ] A review of the existing DELETE requests -- I believe they're solid but they may need updating
+ [ ] A review of the generated links. If a 3rd party adds a completeable post type and uses this endpoint to record completion the resulting links will (potentially) lead to 404s
+ [ ] Tests to simulate progress recording by a 3rd party for a custom post type (we can filter to allow completion of a page and see what happens. It should work).