### PR TITLE
Improve some database query performances by not retrieving found rows…

### DIFF
--- a/class-lifterlms-rest-api.php
+++ b/class-lifterlms-rest-api.php
@@ -238,7 +238,7 @@ final class LifterLMS_REST_API {
 	 *
 	 * @since 1.0.0-beta.1
 	 *
-	 * @return LLMS_REST_API_Webhooks
+	 * @return LLMS_REST_Webhooks
 	 */
 	public function webhooks() {
 		return LLMS_REST_Webhooks::instance();

--- a/includes/class-llms-rest-api-keys-query.php
+++ b/includes/class-llms-rest-api-keys-query.php
@@ -2,10 +2,10 @@
 /**
  * Perform db queries for API Keys
  *
- * @package  LifterLMS_REST/Classes
+ * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,6 +28,7 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 * Retrieve default arguments for a query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Drop usage of `this->get_filter( 'default_args' )` in favor of `'llms_rest_api_key_query_default_args'`.
 	 *
 	 * @return array
 	 */
@@ -48,7 +49,15 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 			return $args;
 		}
 
-		return apply_filters( $this->get_filter( 'default_args' ), $args, $this );
+		/**
+		 * Filters the api keys query default args
+		 *
+		 * @since 1.0.0-beta.1
+		 *
+		 * @param array                    $args           Array of default arguments to set up the query with.
+		 * @param LLMS_REST_API_Keys_Query $api_keys_query Instance of LLMS_REST_API_Keys_Query.
+		 */
+		return apply_filters( 'llms_rest_api_key_query_default_args', $args, $this );
 
 	}
 
@@ -56,6 +65,7 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 * Retrieve an array of LLMS_REST_API_Keys for the given result set returned by the query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Drop usage of `this->get_filter( 'get_keys' )` in favor of `'llms_rest_api_key_query_get_keys'`.
 	 *
 	 * @return array
 	 */
@@ -75,7 +85,15 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 			return $keys;
 		}
 
-		return apply_filters( $this->get_filter( 'get_keys' ), $keys, $this );
+		/**
+		 * Filters the list of API Keys
+		 *
+		 * @since 1.0.0-beta.1
+		 *
+		 * @param LLMS_REST_API_Key[]      $keys           Array of LLMS_REST_API_Key instances.
+		 * @param LLMS_REST_API_Keys_Query $api_keys_query Instance of LLMS_REST_API_Keys_Query.
+		 */
+		return apply_filters( 'llms_rest_api_key_query_get_keys', $keys, $this );
 
 	}
 
@@ -88,12 +106,12 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 */
 	protected function parse_args() {
 
-		// sanitize post & user ids.
+		// Sanitize post & user ids.
 		foreach ( array( 'include', 'exclude', 'user', 'user_not_in' ) as $key ) {
 			$this->arguments[ $key ] = $this->sanitize_id_array( $this->arguments[ $key ] );
 		}
 
-		// validate permissions.
+		// Validate permissions.
 		$permissions = $this->get( 'permissions' );
 		if ( $permissions && ! in_array( $permissions, array_keys( LLMS_REST_API()->keys()->get_permissions() ), true ) ) {
 			$this->arguments['permissions'] = '';
@@ -105,6 +123,7 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 * Prepare the SQL for the query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 *
 	 * @return string
 	 */
@@ -112,7 +131,7 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		return "SELECT SQL_CALC_FOUND_ROWS id
+		return "SELECT {$this->sql_select_columns( 'id' )}
 				FROM {$wpdb->prefix}lifterlms_api_keys
 				{$this->sql_where()}
 				{$this->sql_orderby()}
@@ -124,6 +143,7 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 * SQL "where" clause for the query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Drop usage of `$this->get_filter('where')` in favor of `'llms_rest_api_key_query_where'`.
 	 *
 	 * @return string
 	 */
@@ -169,7 +189,15 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 			return $sql;
 		}
 
-		return apply_filters( $this->get_filter( 'where' ), $sql, $this );
+		/**
+		 * Filters the query WHERE clause
+		 *
+		 * @since 1.0.0-beta.1
+		 *
+		 * @param string                   $sql             The WHERE clause of the query.
+		 * @param LLMS_REST_API_Keys_Query $apy_keys__query Instance of LLMS_REST_API_Keys_Query.
+		 */
+		return apply_filters( 'llms_rest_api_key_query_where', $sql, $this );
 
 	}
 

--- a/includes/class-llms-rest-webhooks-query.php
+++ b/includes/class-llms-rest-webhooks-query.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,7 +20,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	/**
 	 * Identify the Query
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	protected $id = 'rest_webhook';
 
@@ -28,6 +28,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 * Retrieve default arguments for a query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Drop usage of `this->get_filter( 'default_args' )` in favor of `'llms_rest_webhook_query_default_args'`.
 	 *
 	 * @return array
 	 */
@@ -46,7 +47,15 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 			return $args;
 		}
 
-		return apply_filters( $this->get_filter( 'default_args' ), $args, $this );
+		/**
+		 * Filters the webhooks query default args
+		 *
+		 * @since 1.0.0-beta.1
+		 *
+		 * @param array                    $args           Array of default arguments to set up the query with.
+		 * @param LLMS_REST_Webhooks_Query $webhooks_query Instance of LLMS_REST_Webhooks_Query.
+		 */
+		return apply_filters( 'llms_rest_webhook_query_default_args', $args, $this );
 
 	}
 
@@ -54,6 +63,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 * Retrieve an array of LLMS_REST_Webhook objects for the given result set returned by the query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Drop usage of `this->get_filter( 'get_webhooks' )` in favor of `'llms_rest_webhook_query_get_webhooks'`.
 	 *
 	 * @return array
 	 */
@@ -73,7 +83,15 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 			return $hooks;
 		}
 
-		return apply_filters( $this->get_filter( 'get_webhooks' ), $hooks, $this );
+		/**
+		 * Filters the list of webhooks
+		 *
+		 * @since 1.0.0-beta.1
+		 *
+		 * @param LLMS_REST_Webhook[]      $webhooks       Array of LLMS_REST_Webhook instances.
+		 * @param LLMS_REST_Webhooks_Query $webhooks_query Instance of LLMS_REST_Webhooks_Query.
+		 */
+		return apply_filters( 'llms_rest_webhook_query_get_webhooks', $hooks, $this );
 
 	}
 
@@ -86,12 +104,12 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 */
 	protected function parse_args() {
 
-		// sanitize post & user ids.
+		// Sanitize post & user ids.
 		foreach ( array( 'include', 'exclude' ) as $key ) {
 			$this->arguments[ $key ] = $this->sanitize_id_array( $this->arguments[ $key ] );
 		}
 
-		// validate status.
+		// Validate status.
 		$status = $this->get( 'status' );
 		if ( $status && ! in_array( $status, array_keys( LLMS_REST_API()->webhooks()->get_statuses() ), true ) ) {
 			$this->arguments['status'] = '';
@@ -103,6 +121,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 * Prepare the SQL for the query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 *
 	 * @return string
 	 */
@@ -110,7 +129,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		return "SELECT SQL_CALC_FOUND_ROWS id
+		return "SELECT {$this->sql_select_columns( 'id' )}
 				FROM {$wpdb->prefix}lifterlms_webhooks
 				{$this->sql_where()}
 				{$this->sql_orderby()}
@@ -122,6 +141,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 * SQL "where" clause for the query
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Drop usage of `$this->get_filter('where')` in favor of `'llms_rest_webhook_query_where'`.
 	 *
 	 * @return string
 	 */
@@ -165,7 +185,15 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 			return $sql;
 		}
 
-		return apply_filters( $this->get_filter( 'where' ), $sql, $this );
+		/**
+		 * Filters the query WHERE clause
+		 *
+		 * @since 1.0.0-beta.1
+		 *
+		 * @param string                   $sql            The WHERE clause of the query.
+		 * @param LLMS_REST_Webhooks_Query $webhooks_query Instance of LLMS_REST_Webhooks_Query.
+		 */
+		return apply_filters( 'llms_rest_webhook_query_where', $sql, $this );
 
 	}
 

--- a/includes/class-llms-rest-webhooks.php
+++ b/includes/class-llms-rest-webhooks.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.11
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -475,9 +475,10 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	}
 
 	/**
-	 * Load webhooks.
+	 * Load webhooks
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version]
 	 *
 	 * @return int Number of hooks loaded.
 	 */
@@ -487,15 +488,17 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 		 * Limit the number of webhooks that are loaded. By default all webhooks are loaded.
 		 *
 		 * @since 1.0.0-beta.1
-		 *
+		 * @since [version] When retrieving the webhooks, instantiate the webhooks query passing `no_found_rows` arg as `true`,
+		 *                     to improve performance (no pagination is needed).
 		 * @param int $limit Number of webhooks to load. Default `null` loads all webhooks.
 		 */
 		$limit = apply_filters( 'llms_load_webhooks_limit', null );
 
 		$hooks = new LLMS_REST_Webhooks_Query(
 			array(
-				'status'   => 'active',
-				'per_page' => $limit ? $limit : 999,
+				'status'        => 'active',
+				'per_page'      => $limit ? $limit : 999,
+				'no_found_rows' => true,
 			)
 		);
 


### PR DESCRIPTION
… when not needed

## Description
Per https://github.com/gocodebox/lifterlms/issues/933

Also get rid of get_filter() in the `LLMS_REST_Webhooks_Query` and `LLMS_REST_API_Keys_Query` classes.

## How has this been tested?
existing unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
performance improvements

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

