### PR TITLE
l10n bug fixes and LLMS core compatibility

### DIFF
--- a/.bin/cache-bust
+++ b/.bin/cache-bust
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+/**
+ * Cachebust the openapi.json file powering the static html page
+ *
+ * Adds a version query string variable to the deployed static html index file
+ * and, in doing so, ensures that the latest version will be loaded (instead of a
+ * possibly outdated cached version).
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+const
+	fs   = require( 'fs' ),
+	pkg  = require( '../package.json' ),
+	file = `${ process.cwd() }/web_deploy/index.html`,
+	html = fs.readFileSync( `${ process.cwd() }/web_deploy/index.html` ).toString();
+
+fs.writeFileSync( file, html.replace( `'./openapi.json',`, `'./openapi.json?v=${ pkg.version }'` ) );

--- a/.bin/cache-bust
+++ b/.bin/cache-bust
@@ -17,4 +17,4 @@ const
 	file = `${ process.cwd() }/web_deploy/index.html`,
 	html = fs.readFileSync( `${ process.cwd() }/web_deploy/index.html` ).toString();
 
-fs.writeFileSync( file, html.replace( `'./openapi.json',`, `'./openapi.json?v=${ pkg.version }'` ) );
+fs.writeFileSync( file, html.replace( `'./openapi.json'`, `'./openapi.json?v=${ pkg.version }'` ) );

--- a/class-lifterlms-rest-api.php
+++ b/class-lifterlms-rest-api.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST_API/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,10 +16,6 @@ require_once LLMS_REST_API_PLUGIN_DIR . 'includes/traits/class-llms-rest-trait-s
  * LifterLMS_REST_API class.
  *
  * @since 1.0.0-beta.1
- * @since 1.0.0-beta.4 Load authentication early.
- * @since 1.0.0-beta.6 Load webhook actions early.
- * @since 1.0.0-beta.8 Load webhook actions a little bit later, to avoid PHP warnings on first plugin activation.
- * @since 1.0.0-beta.9 Added memberships controller.
  */
 final class LifterLMS_REST_API {
 
@@ -37,6 +33,7 @@ final class LifterLMS_REST_API {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.4 Load authentication early.
+	 * @since [version] Only localize when loaded as an independent plugin.
 	 *
 	 * @return void
 	 */
@@ -46,8 +43,14 @@ final class LifterLMS_REST_API {
 			define( 'LLMS_REST_API_VERSION', $this->version );
 		}
 
-		// i18n.
-		add_action( 'init', array( $this, 'load_textdomain' ), 0 );
+		/**
+		 * When loaded as a library included by the LifterLMS core localization is handled by the LifterLMS core.
+		 *
+		 * When the plugin is loaded by itself as a plugin, we must localize it independently.
+		 */
+		if ( ! defined( 'LLMS_REST_API_LIB' ) || ! LLMS_REST_API_LIB ) {
+			add_action( 'init', array( $this, 'load_textdomain' ), 0 );
+		}
 
 		// Authentication needs to run early to handle basic auth.
 		include_once LLMS_REST_API_PLUGIN_DIR . 'includes/class-llms-rest-authentication.php';
@@ -208,6 +211,7 @@ final class LifterLMS_REST_API {
 
 	/**
 	 * Load l10n files.
+	 *
 	 * The first loaded file takes priority.
 	 *
 	 * Files can be found in the following order:
@@ -215,6 +219,8 @@ final class LifterLMS_REST_API {
 	 *      WP_LANG_DIR/plugins/lifterlms-LOCALE.mo
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed the name of the MO loaded from the safe directory: `lifterlms-{$locale}.mo` to `lifterlms-rest-{$locale}.mo`.
+	 *                      Fixed double slash typo in plugin textdomain path argument.
 	 *
 	 * @return void
 	 */
@@ -223,11 +229,11 @@ final class LifterLMS_REST_API {
 		// load locale.
 		$locale = apply_filters( 'plugin_locale', get_locale(), 'lifterlms' );
 
-		// load a lifterlms specific locale file if one exists.
-		load_textdomain( 'lifterlms', WP_LANG_DIR . '/lifterlms/lifterlms-' . $locale . '.mo' );
+		// Load from the LifterLMS "safe" directory if it exists.
+		load_textdomain( 'lifterlms', WP_LANG_DIR . '/lifterlms/lifterlms-rest' . $locale . '.mo' );
 
-		// load localization files.
-		load_plugin_textdomain( 'lifterlms', false, dirname( plugin_basename( __FILE__ ) ) . '//i18n' );
+		// Load localization files.
+		load_plugin_textdomain( 'lifterlms', false, LLMS_REST_API_PLUGIN_DIR . '/i18n' );
 
 	}
 

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -337,7 +337,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 				'arg_options' => array(
 					'sanitize_callback' => 'absint',
 				),
-				'readonly'   => true,
+				'readonly'    => true,
 			),
 			'order'        => array(
 				'description' => __( 'Order of the lesson within its immediate parent.', 'lifterlms' ),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "npm run build:docs && llms-dev pot",
     "build:docs": "npm run build:spec && npm run build:snippets && npm run build:spec",
     "build:snippets": "./.bin/snippets",
-    "build:spec": "swagger-repo build -o web_deploy",
+    "build:spec": "swagger-repo build -o web_deploy && ./.bin/cache-bust",
     "test": "swagger-repo validate",
     "gh-pages": "swagger-repo gh-pages"
   }

--- a/tests/framework/class-llms-rest-unit-test-case-server.php
+++ b/tests/framework/class-llms-rest-unit-test-case-server.php
@@ -6,6 +6,7 @@
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.11 Fixed pagination test taking into account post revisions.
+ * @version [version]
  */
 
 class LLMS_REST_Unit_Test_Case_Server extends LLMS_REST_Unit_Test_Case_Base {
@@ -134,8 +135,9 @@ class LLMS_REST_Unit_Test_Case_Server extends LLMS_REST_Unit_Test_Case_Base {
 	 * Utility to perform pagination test
 	 *
 	 * @since 1.0.0-beta.7
- 	 * @since 1.0.0-beta.11 Post revisions are now taken into account when comparing list of resource ids.
- 	 *
+	 * @since 1.0.0-beta.11 Post revisions are now taken into account when comparing list of resource ids.
+	 * @since [version] Better accounting of the automatic creation of post revisions.
+	 *
 	 * @param string   $route    Optional. Request route, eg: '/llms/v1/courses'. Default empty string, will fall back on this->route.
 	 * @param int      $start_id Optional. The id of the first item. Default `1`.
 	 * @param int      $per_page Optional. The number of items per page. Default `10`.
@@ -150,7 +152,7 @@ class LLMS_REST_Unit_Test_Case_Server extends LLMS_REST_Unit_Test_Case_Base {
 		$total_pages = (int) ceil( $total / $per_page );
 		$initial_id  = $start_id;
 		if ( is_null( $ids_step ) ) {
-			$ids_step = isset( $this->post_type ) && post_type_supports( $this->post_type, 'revisions' ) ? 2 : 1;
+			$ids_step = isset( $this->post_type ) && post_type_supports( $this->post_type, 'revisions' ) && ! empty( $this->generates_revision_on_creation ) ? 2 : 1;
 		}
 
 		for ( $i = 1; $i <= $total_pages; $i++ ) {

--- a/tests/unit-tests/server/class-llms-rest-test-courses.php
+++ b/tests/unit-tests/server/class-llms-rest-test-courses.php
@@ -19,7 +19,7 @@
  *                     Use `$this->perform_mock_request()` and `$this->assertResponseStatusEquals()` utils.
  *                     Added `@return` to doc.
  *                     Use the far less predictable `wp_wp_rand()` in place of `wp_rand()`.
- * @version 1.0.0-beta.8
+ * @version [version]
  *
  * @todo update tests to check links.
  * @todo do more tests on the courses update/delete.
@@ -51,6 +51,14 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 		'course_tag',
 		'course_track',
 	);
+
+	/**
+	 * This is an internal flag we use to determine whether or not
+	 * we need to use a step of 2 ids when testing the pagination.
+	 *
+	 * @var array
+	 */
+	protected $generates_revision_on_creation = true;
 
 	/**
 	 *

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -348,10 +348,11 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 
 		wp_set_current_user( $this->user_allowed );
 
-		// create sections
-		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 25 ) );
+		// Create lessons.
+		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 25, 'quiz' => 0 ) );
 		$start_lesson_id = $course->get_lessons( 'ids' )[0];
 
+		// When crea
 		$this->pagination_test( $this->route, $start_lesson_id );
 
 	}
@@ -367,7 +368,7 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 
 		wp_set_current_user( $this->user_allowed );
 
-		// create a parent course, a prerequisite and a quiz.
+		// Create a parent course, a prerequisite and a quiz.
 		$course_id           = $this->factory->course->create(
 			array(
 				'sections' => 1,

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -352,7 +352,6 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 25, 'quiz' => 0 ) );
 		$start_lesson_id = $course->get_lessons( 'ids' )[0];
 
-		// When crea
 		$this->pagination_test( $this->route, $start_lesson_id );
 
 	}

--- a/tests/unit-tests/server/class-llms-rest-test-memberships.php
+++ b/tests/unit-tests/server/class-llms-rest-test-memberships.php
@@ -9,6 +9,7 @@
  *
  * @since 1.0.0-beta.9
  * @since 1.0.0-beta.11 Fixed `post_type` property.
+ * @version [version]
  *
  * @todo do more tests on the membership update/delete.
  */
@@ -44,6 +45,14 @@ class LLMS_REST_Test_Memberships extends LLMS_REST_Unit_Test_Case_Posts {
 	 * @var array
 	 */
 	protected $sample_membership_args = array();
+
+	/**
+	 * This is an internal flag we use to determine whether or not
+	 * we need to use a step of 2 ids when testing the pagination.
+	 *
+	 * @var array
+	 */
+	protected $generates_revision_on_creation = true;
 
 	/**
 	 * @since 1.0.0-beta.9


### PR DESCRIPTION

## Description
<!-- Please describe what you have changed or added -->

Fixes 2 untracked bugs related to localization of the plugin:
+ Fixed the name of the MO loaded from the safe directory: `lifterlms-{$locale}.mo` to `lifterlms-rest-{$locale}.mo`.
+ Fixed double slash typo in plugin textdomain path argument.

Additionally, per https://github.com/gocodebox/lifterlms/issues/1141:

Only loads the plugin's localization functions when the plugin is loaded as a plugin. When the plugin is loaded as a library from within the LifterLMS core (see related ...)

## How has this been tested?
Manually

## Types of changes
Bug fix & l10n improvements

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

