### PR TITLE
Bug fixes on localization loading and only localize when the plugin i…

### DIFF
--- a/class-lifterlms-rest-api.php
+++ b/class-lifterlms-rest-api.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST_API/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,10 +16,6 @@ require_once LLMS_REST_API_PLUGIN_DIR . 'includes/traits/class-llms-rest-trait-s
  * LifterLMS_REST_API class.
  *
  * @since 1.0.0-beta.1
- * @since 1.0.0-beta.4 Load authentication early.
- * @since 1.0.0-beta.6 Load webhook actions early.
- * @since 1.0.0-beta.8 Load webhook actions a little bit later, to avoid PHP warnings on first plugin activation.
- * @since 1.0.0-beta.9 Added memberships controller.
  */
 final class LifterLMS_REST_API {
 
@@ -37,6 +33,7 @@ final class LifterLMS_REST_API {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.4 Load authentication early.
+	 * @since [version] Only localize when loaded as an independent plugin.
 	 *
 	 * @return void
 	 */
@@ -46,8 +43,14 @@ final class LifterLMS_REST_API {
 			define( 'LLMS_REST_API_VERSION', $this->version );
 		}
 
-		// i18n.
-		add_action( 'init', array( $this, 'load_textdomain' ), 0 );
+		/**
+		 * When loaded as a library included by the LifterLMS core localization is handled by the LifterLMS core.
+		 *
+		 * When the plugin is loaded by itself as a plugin, we must localize it independently.
+		 */
+		if ( ! defined( 'LLMS_REST_API_LIB' ) || ! LLMS_REST_API_LIB ) {
+			add_action( 'init', array( $this, 'load_textdomain' ), 0 );
+		}
 
 		// Authentication needs to run early to handle basic auth.
 		include_once LLMS_REST_API_PLUGIN_DIR . 'includes/class-llms-rest-authentication.php';
@@ -208,6 +211,7 @@ final class LifterLMS_REST_API {
 
 	/**
 	 * Load l10n files.
+	 *
 	 * The first loaded file takes priority.
 	 *
 	 * Files can be found in the following order:
@@ -215,6 +219,8 @@ final class LifterLMS_REST_API {
 	 *      WP_LANG_DIR/plugins/lifterlms-LOCALE.mo
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed the name of the MO loaded from the safe directory: `lifterlms-{$locale}.mo` to `lifterlms-rest-{$locale}.mo`.
+	 *                      Fixed double slash typo in plugin textdomain path argument.
 	 *
 	 * @return void
 	 */
@@ -223,11 +229,11 @@ final class LifterLMS_REST_API {
 		// load locale.
 		$locale = apply_filters( 'plugin_locale', get_locale(), 'lifterlms' );
 
-		// load a lifterlms specific locale file if one exists.
-		load_textdomain( 'lifterlms', WP_LANG_DIR . '/lifterlms/lifterlms-' . $locale . '.mo' );
+		// Load from the LifterLMS "safe" directory if it exists.
+		load_textdomain( 'lifterlms', WP_LANG_DIR . '/lifterlms/lifterlms-rest' . $locale . '.mo' );
 
-		// load localization files.
-		load_plugin_textdomain( 'lifterlms', false, dirname( plugin_basename( __FILE__ ) ) . '//i18n' );
+		// Load localization files.
+		load_plugin_textdomain( 'lifterlms', false, LLMS_REST_API_PLUGIN_DIR . '/i18n' );
 
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes 2 untracked bugs related to localization of the plugin:
+ Fixed the name of the MO loaded from the safe directory: `lifterlms-{$locale}.mo` to `lifterlms-rest-{$locale}.mo`.
+ Fixed double slash typo in plugin textdomain path argument.

Additionally, per https://github.com/gocodebox/lifterlms/issues/1141:

Only loads the plugin's localization functions when the plugin is loaded as a plugin. When the plugin is loaded as a library from within the LifterLMS core (see related https://github.com/gocodebox/lifterlms/pull/1434)

## How has this been tested?
Manually

## Types of changes
Bug fix & l10n improvements

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->