### PR TITLE
Fix failed webhook delivery preventing it from being delivered again

### DIFF
--- a/includes/abstracts/class-llms-rest-webhook-data.php
+++ b/includes/abstracts/class-llms-rest-webhook-data.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.6 Retrieve proper payload for enrollment and progress resources.
+ * @since [version] Remove unused 'pending_delivery' column.
  */
 abstract class LLMS_REST_Webhook_Data extends LLMS_Abstract_Database_Store {
 
@@ -34,7 +35,6 @@ abstract class LLMS_REST_Webhook_Data extends LLMS_Abstract_Database_Store {
 		'created'          => '%s',
 		'updated'          => '%s',
 		'failure_count'    => '%d',
-		'pending_delivery' => '%d',
 
 	);
 

--- a/includes/class-llms-rest-install.php
+++ b/includes/class-llms-rest-install.php
@@ -5,9 +5,8 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.1
+ * @version [version]
  */
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -34,7 +33,7 @@ class LLMS_REST_Install {
 	 *
 	 * @since 1.0.0-beta.1
 	 *
-	 * @return   void
+	 * @return void
 	 */
 	public static function check_version() {
 		if ( ! defined( 'IFRAME_REQUEST' ) && get_option( 'llms_rest_version' ) !== LLMS_REST_API()->version ) {
@@ -48,6 +47,7 @@ class LLMS_REST_Install {
 	 * Adds REST API Keys table to the LifterLMS DB Table Schema
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Remove unused 'pending_delivery' column.
 	 *
 	 * @see LLMS_Install::get_schema()
 	 *
@@ -84,7 +84,6 @@ CREATE TABLE `{$wpdb->prefix}lifterlms_webhooks` (
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `failure_count` smallint(3) unsigned NOT NULL DEFAULT '0',
-  `pending_delivery` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`)
 ) $collate;

--- a/includes/class-llms-rest-install.php
+++ b/includes/class-llms-rest-install.php
@@ -7,6 +7,7 @@
  * @since 1.0.0-beta.1
  * @version [version]
  */
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/class-llms-rest-webhooks.php
+++ b/includes/class-llms-rest-webhooks.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.16
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -66,6 +66,7 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	 * Create a new API Key
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Remove reference to 'pending_delivery' (unused) column.
 	 *
 	 * @param array $data Associative array of data to set to a key's properties.
 	 * @return WP_Error|LLMS_REST_Webhook
@@ -76,9 +77,6 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 		if ( is_wp_error( $data ) ) {
 			return $data;
 		}
-
-		// Can't set these properties during creation.
-		unset( $data['pending_delivery'], $data['failure_count'] );
 
 		return $this->save( new $this->model(), $data );
 
@@ -109,7 +107,8 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.3 Fix formatting error.
-	 *
+ 	 * @since [version] Remove reference to 'pending_delivery' (unused) column.
+ 	 *
 	 * @return array
 	 */
 	public function get_default_column_values() {
@@ -118,7 +117,6 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 			'secret'           => wp_generate_password( 50, true, true ),
 			'status'           => 'disabled',
 			'failure_count'    => 0,
-			'pending_delivery' => 0,
 			'user_id'          => get_current_user_id(),
 			'name'             => sprintf(
 				// Translators: %s = created date.
@@ -542,6 +540,7 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	 * Prepare data for an update.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Remove reference to 'pending_delivery' (unused) column.
 	 *
 	 * @param array $data Associative array of data to set to a resources properties.
 	 * @return LLMS_REST_Webhook|WP_Error
@@ -552,7 +551,6 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 
 		// Merge in (some) default values.
 		$defaults = $this->get_default_column_values();
-		unset( $defaults['pending_delivery'], $defaults['failure_count'] );
 		$data = wp_parse_args( array_filter( $data ), $defaults );
 
 		// URL was supplied but empty so add it back in to get caught by validation.

--- a/includes/class-llms-rest-webhooks.php
+++ b/includes/class-llms-rest-webhooks.php
@@ -110,18 +110,18 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.3 Fix formatting error.
- 	 * @since [version] Remove reference to 'pending_delivery' (unused) column.
- 	 *
+	 * @since [version] Remove reference to 'pending_delivery' (unused) column.
+	 *
 	 * @return array
 	 */
 	public function get_default_column_values() {
 
 		$this->default_column_values = array(
-			'secret'           => wp_generate_password( 50, true, true ),
-			'status'           => 'disabled',
-			'failure_count'    => 0,
-			'user_id'          => get_current_user_id(),
-			'name'             => sprintf(
+			'secret'        => wp_generate_password( 50, true, true ),
+			'status'        => 'disabled',
+			'failure_count' => 0,
+			'user_id'       => get_current_user_id(),
+			'name'          => sprintf(
 				// Translators: %s = created date.
 				__( 'Webhook created on %s', 'lifterlms' ),
 				// Translators: Date format.

--- a/includes/class-llms-rest-webhooks.php
+++ b/includes/class-llms-rest-webhooks.php
@@ -78,6 +78,9 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 			return $data;
 		}
 
+		// Can't set this property during creation.
+		unset( $data['failure_count'] );
+
 		return $this->save( new $this->model(), $data );
 
 	}
@@ -551,6 +554,7 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 
 		// Merge in (some) default values.
 		$defaults = $this->get_default_column_values();
+		unset( $defaults['failure_count'] );
 		$data = wp_parse_args( array_filter( $data ), $defaults );
 
 		// URL was supplied but empty so add it back in to get caught by validation.

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -499,7 +499,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 		 * @param array             $args  Numeric array of arguments from the originating hook.
 		 * @param LLMS_REST_Webhook $this  Webhook object.
 		 */
-		$delay = apply_filters( 'llms_rest_webhook_repeat_delay', 3, $args, $this );
+		$delay = apply_filters( 'llms_rest_webhook_repeat_delay', 300, $args, $this );
 
 		if ( ! $next || $next >= ( $delay + gmdate( 'U' ) ) ) {
 

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -188,19 +188,6 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	}
 
 	/**
-	 * Determine if the webhook is currently pending delivery
-	 *
-	 * @since 1.0.0-beta.1
-	 *
-	 * @return bool
-	 */
-	public function is_pending() {
-
-		return llms_parse_bool( $this->get( 'pending_delivery' ) );
-
-	}
-
-	/**
 	 * Checks if the specified resource has already been queued for delivery within the current request
 	 *
 	 * Helps avoid duplication of data being sent for topics that have more than one hook defined.

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -21,6 +21,14 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 
 	/**
+	 * Store which object IDs this webhook has processed (ie scheduled to be delivered)
+	 * within the current page request.
+	 *
+	 * @var array
+	 */
+	protected $processed = array();
+
+	/**
 	 * Delivers the webhook
 	 *
 	 * @since 1.0.0-beta.1
@@ -97,6 +105,8 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * Logs data when loggind enabled and updates state data.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Stop setting the webhook's property `pending_delivery` to 0.
+	 *                      We now rely on the method `is_already_processed()` to determine whether the webhook delivering should be avoided.
 	 *
 	 * @param string $delivery_id Webhook delivery id (for logging).
 	 * @param array  $req_args    HTTP Request Arguments used to deliver the webhook.
@@ -160,8 +170,6 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 			$this->set_delivery_failure();
 		}
 
-		$this->set( 'pending_delivery', 0 )->save();
-
 	}
 
 	/**
@@ -190,6 +198,18 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 
 		return llms_parse_bool( $this->get( 'pending_delivery' ) );
 
+	}
+
+	/**
+	 * Checks if the specified resource has already been queued for delivery within the current request
+	 *
+	 * Helps avoid duplication of data being sent for topics that have more than one hook defined.
+	 *
+	 * @param array $args Numeric array of arguments from the originating hook.
+	 * @return bool
+	 */
+	protected function is_already_processed( $args ) {
+		return false !== array_search( $args[0], $this->processed, true );
 	}
 
 	/**
@@ -339,8 +359,10 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * Determines if the webhook should be delivered and whether or not it should be scheduled or delivered immediately.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request.
+	 *                      And don't rely anymore on the webhook's `pending_delivery` property to achieve the same goal.
 	 *
-	 * @param mixed ...$args Aguments from the hook.
+	 * @param mixed ...$args Arguments from the hook.
 	 * @return int|false Timestamp of the scheduled event when the webhook is successfully scheduled.
 	 *                   false if the webhook should not be delivered or has already been delivered in the last 5 minutes.
 	 */
@@ -349,6 +371,10 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 		if ( ! $this->should_deliver( $args ) ) {
 			return false;
 		}
+
+		// Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request,
+		// as it might happen with webhooks with multiple hookes defined in `LLMS_REST_Webhooks::get_hooks()`.
+		$this->processed[] = $args[0];
 
 		/**
 		 * Disable background processing of webhooks by returning a falsy
@@ -362,8 +388,6 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 		if ( apply_filters( 'llms_rest_webhook_deliver_async', true, $this, $args ) ) {
 			return $this->schedule( $args );
 		}
-
-		$this->set( 'pending_delivery', 1 )->save();
 
 		return $this->deliver( $args );
 
@@ -411,6 +435,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * Determines if an originating action qualifies for webhook delivery
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [verison] Drop checking whether the webhook is pending in favor of a check on if is already processed within the current request.
 	 *
 	 * @param array $args Numeric array of arguments from the originating hook.
 	 * @return bool
@@ -418,9 +443,9 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	protected function should_deliver( $args ) {
 
 		$deliver = ( 'active' === $this->get( 'status' ) ) // Must be active.
-			&& ! $this->is_pending() // Not already pending.
 			&& $this->is_valid_action( $args ) // Valid action.
-			&& $this->is_valid_resource( $args ); // Valid resource.
+			&& $this->is_valid_resource( $args ) // Valid resource.
+			&& ! $this->is_already_processed( $args ); // Not already processed.
 
 		/**
 		 * Skip or hijack webhook delivery scheduling
@@ -437,6 +462,8 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * Schedule the webhook for async delivery
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Stop setting the webhook's property `pending_delivery` to 1 when scheduling the delivery.
+	 *                      We now rely on the method `is_already_processed()` to determine whether the webhook scheduling should be avoided.
 	 *
 	 * @param array $args Numeric array of arguments from the originating hook.
 	 * @return bool
@@ -472,11 +499,10 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 		 * @param array             $args  Numeric array of arguments from the originating hook.
 		 * @param LLMS_REST_Webhook $this  Webhook object.
 		 */
-		$delay = apply_filters( 'llms_rest_webhook_repeat_delay', 300, $args, $this );
+		$delay = apply_filters( 'llms_rest_webhook_repeat_delay', 3, $args, $this );
 
 		if ( ! $next || $next >= ( $delay + gmdate( 'U' ) ) ) {
 
-			$this->set( 'pending_delivery', 1 )->save();
 			return as_schedule_single_action( time(), 'lifterlms_rest_deliver_webhook_async', $schedule_args, 'llms-webhooks' ) ? true : false;
 
 		}

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -563,27 +563,6 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 	}
 
 	/**
-	 * Test is pending checker method.
-	 *
-	 * @since 1.0.0-beta.1
-	 *
-	 * @return void
-	 */
-	public function test_is_pending() {
-
-		$webhook = LLMS_REST_API()->webhooks()->create( array(
-			'delivery_url' => 'https://fake.tld',
-			'topic' => 'course.created',
-		) );
-
-		$this->assertFalse( $webhook->is_pending() );
-
-		$webhook->set( 'pending_delivery', 1 );
-
-		$this->assertTrue( $webhook->is_pending() );
-	}
-
-	/**
 	 * Test validity of post actions.
 	 *
 	 * @since 1.0.0-beta.1

--- a/tests/unit-tests/class-llms-rest-test-webhooks.php
+++ b/tests/unit-tests/class-llms-rest-test-webhooks.php
@@ -111,7 +111,6 @@ class LLMS_REST_Test_Webhooks extends LLMS_REST_Unit_Test_Case_Base {
 
 		$this->assertEquals( 'disabled', $ret->get( 'status' ) );
 		$this->assertEquals( 0, $ret->get( 'failure_count' ) );
-		$this->assertEquals( 0, $ret->get( 'pending_delivery' ) );
 		$this->assertEquals( $user_id, $ret->get( 'user_id' ) );
 
 		$this->assertEquals( 50, strlen( $ret->get( 'secret' ) ) );
@@ -343,7 +342,6 @@ class LLMS_REST_Test_Webhooks extends LLMS_REST_Unit_Test_Case_Base {
 		$this->assertEquals( 50, strlen( $vals['secret'] ) );
 		$this->assertEquals( 'disabled', $vals['status'] );
 		$this->assertEquals( 0, $vals['failure_count'] );
-		$this->assertEquals( 0, $vals['pending_delivery'] );
 
 	}
 
@@ -454,7 +452,6 @@ class LLMS_REST_Test_Webhooks extends LLMS_REST_Unit_Test_Case_Base {
 			'id' => $hook->get( 'id' ),
 			'topic' => 'action.mock',
 			'delivery_url' => 'http://mock.com',
-			'pending_delivery' => 1,
 			'failure_count' => 5,
 			'name' => 'Changed it',
 			'secret' => 'new secret',


### PR DESCRIPTION
## Description
Fixes #210

## How has this been tested?
Manually and with existing and new tests.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->


@thomasplevy 
as said in #210 
we could even totally remove the `pending_delivery` property and the logic related to it. I didn't do it yet because I wanted to know your opinion on this. I guess that, since we're in beta, we can get rid of public methods without problems, right?

Also, we should remove the related db column, this means that we need an update routine. But you know, I don't know if it's worthwhile to implement all the "bg db update" logic here, or just implement this minor update in core or whatever. Ideas?