### PR TITLE
Replace preprare_query with prepare_query

### DIFF
--- a/includes/class-llms-rest-api-keys-query.php
+++ b/includes/class-llms-rest-api-keys-query.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.16
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -124,10 +124,11 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.16 Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 * @since [version] Renamed from `preprare_query()`.
 	 *
 	 * @return string
 	 */
-	protected function preprare_query() {
+	protected function prepare_query() {
 
 		global $wpdb;
 

--- a/includes/class-llms-rest-webhooks-query.php
+++ b/includes/class-llms-rest-webhooks-query.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.16
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -122,10 +122,11 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.16 Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 * @since [version] Renamed from `preprare_query()`.
 	 *
 	 * @return string
 	 */
-	protected function preprare_query() {
+	protected function prepare_query() {
 
 		global $wpdb;
 


### PR DESCRIPTION
## Description

Per https://github.com/gocodebox/lifterlms/issues/859

Updates classes extending `LLMS_Database_Query` to use `prepare_query` in favor of `preprare_query`

This will require bumping the LLMS core required version. This will rely on core updates (and the core will rely on this update) so we'll have to release them alongside each other.

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

