### PR TITLE
deprecated `llms_user_removed_from_membership_level` action hook

### DIFF
--- a/.changelogs/llms-user-removed-from-membership.yml
+++ b/.changelogs/llms-user-removed-from-membership.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Replaced deprecated `llms_user_removed_from_membership_level` action hook with `llms_user_removed_from_membership`.

--- a/includes/class-llms-rest-webhooks.php
+++ b/includes/class-llms-rest-webhooks.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.18
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -239,6 +239,7 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.11 `'save_post_*'` hooks number of arguments reduced to two.
+	 * @since [version] Replaced deprecated `llms_user_removed_from_membership_level` action hook with `llms_user_removed_from_membership`.
 	 *
 	 * @return array
 	 */
@@ -371,7 +372,7 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 				'llms_user_course_enrollment_updated'     => 2,
 				'llms_user_membership_enrollment_updated' => 2,
 				'llms_user_removed_from_course'           => 2,
-				'llms_user_removed_from_membership_level' => 2,
+				'llms_user_removed_from_membership'       => 2,
 			),
 			'enrollment.deleted'  => array(
 				'llms_user_enrollment_deleted' => 2,


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Replaced deprecated `llms_user_removed_from_membership_level` action hook with `llms_user_removed_from_membership`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [X] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

