### PR TITLE
`LLMS_Section::get_parent_course()`

### DIFF
--- a/.changelogs/get-parent-course.yml
+++ b/.changelogs/get-parent-course.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Replaced call to deprecated `LLMS_Section::get_parent_course()` with `LLMS_Section::get( 'parent_course' )`.

--- a/includes/server/class-llms-rest-sections-controller.php
+++ b/includes/server/class-llms-rest-sections-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.21
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -331,6 +331,7 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 	 * Prepare a single object output for response.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Replaced call to deprecated `LLMS_Section::get_parent_course()` with `LLMS_Section::get( 'parent_course' )`.
 	 *
 	 * @param LLMS_Section    $section Section object.
 	 * @param WP_REST_Request $request Full details about the request.
@@ -341,7 +342,7 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		$data = parent::prepare_object_for_response( $section, $request );
 
 		// Parent course.
-		$data['parent_id'] = $section->get_parent_course();
+		$data['parent_id'] = $section->get( 'parent_course' );
 
 		// Order.
 		$data['order'] = $section->get( 'order' );
@@ -409,6 +410,7 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.7 Fix the way we get the section's parent course object.
 	 * @since 1.0.0-beta.14 Added `$request` parameter.
+	 * @since [version] Replaced call to deprecated `LLMS_Section::get_parent_course()` with `LLMS_Section::get( 'parent_course' )`.
 	 *
 	 * @param LLMS_Section    $section LLMS Section.
 	 * @param WP_REST_Request $request Request object.
@@ -417,7 +419,7 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 	protected function prepare_links( $section, $request ) {
 
 		$links            = parent::prepare_links( $section, $request );
-		$parent_course_id = $section->get_parent_course();
+		$parent_course_id = $section->get( 'parent_course' );
 
 		// If the section has no course parent return earlier.
 		if ( ! $parent_course_id ) {


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Replaced call to deprecated [`LLMS_Section::get_parent_course()`](https://github.com/gocodebox/lifterlms/blob/5.6.0/includes/models/model.llms.section.php#L297) with `LLMS_Section::get( 'parent_course' )`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [X] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

