### PR TITLE
Replace calls to deprecated `LLMS_Lesson::get_parent_course()`

### DIFF
--- a/.changelogs/llms-lesson-get-parent-course.yml
+++ b/.changelogs/llms-lesson-get-parent-course.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Replaced the calls to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.21
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -107,6 +107,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	 *
 	 * @since 1.0.0-beta.7
 	 * @since 1.0.0-beta.15 Fixed setting/updating parent section/course.
+	 * @since [version] Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return array|WP_Error Array of lesson args or WP_Error.
@@ -147,7 +148,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 			 */
 			if ( $request['id'] ) {
 				$lesson = $this->get_object( $request['id'] );
-				if ( $lesson && $parent_course_id === $lesson->get_parent_course() ) {
+				if ( $lesson && $parent_course_id === $lesson->get( 'parent_course' ) ) {
 					unset( $prepared_item['parent_course'] );
 				}
 			}
@@ -531,6 +532,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	 * @since 1.0.0-beta.7 Added following properties to the response object:
 	 *                  public, points, quiz, drip_method, drip_days, drip_date, prerequisite, audio_embed, video_embed.
 	 *                  Added `llms_rest_prepare_lesson_object_response` filter hook.
+	 * @since [version] Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
 	 *
 	 * @param LLMS_Lesson     $lesson Lesson object.
 	 * @param WP_REST_Request $request Full details about the request.
@@ -550,7 +552,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		$data['parent_id'] = $lesson->get_parent_section();
 
 		// Parent course.
-		$data['course_id'] = $lesson->get_parent_course();
+		$data['course_id'] = $lesson->get( 'parent_course' );
 
 		// Order.
 		$data['order'] = $lesson->get( 'order' );
@@ -711,6 +713,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	 *                  Following links added: `prerequisite`, `quiz`.
 	 *                  Added `llms_rest_lesson_links` filter hook.
 	 * @since 1.0.0-beta.14 Added `$request` parameter.
+	 * @since [version] Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
 	 *
 	 * @param LLMS_Lesson     $lesson  LLMS Section.
 	 * @param WP_REST_Request $request Request object.
@@ -723,7 +726,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		unset( $links['content'] );
 
 		$lesson_id         = $lesson->get( 'id' );
-		$parent_course_id  = $lesson->get_parent_course();
+		$parent_course_id  = $lesson->get( 'parent_course' );
 		$parent_section_id = $lesson->get_parent_section();
 
 		$lesson_links = array();
@@ -804,8 +807,9 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	 * Checks if a Lesson can be read
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
 	 *
-	 * @param LLMS_Lesson $lesson The Lesson oject.
+	 * @param LLMS_Lesson $lesson The Lesson object.
 	 * @return bool Whether the post can be read.
 	 *
 	 * @todo Implement read permission based on the section's id:
@@ -816,7 +820,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		/**
 		 * As of now, lessons of password protected courses cannot be read
 		 */
-		if ( post_password_required( $lesson->get_parent_course() ) ) {
+		if ( post_password_required( $lesson->get( 'parent_course' ) ) ) {
 			return false;
 		}
 

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -710,9 +710,10 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 	 * Override.
 	 *
 	 * @since 1.0.0-beta.7
+	 * @since [version] Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
 	 *
-	 * @param $expected array Array of expected properties.
-	 * @param $lesson LLMS_Post Instance of LLMS_Post.
+	 * @param array           $expected Array of expected properties.
+	 * @param LLMS_Post_Model $lesson   Instance of LLMS_Post_Model.
 	 * @return array
 	 */
 	protected function filter_expected_fields( $expected, $lesson ) {
@@ -727,7 +728,7 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 		$expected['parent_id'] = $lesson->get_parent_section();
 
 		// Parent course.
-		$expected['course_id'] = $lesson->get_parent_course();
+		$expected['course_id'] = $lesson->get( 'parent_course' );
 
 		// Order.
 		$expected['order'] = $lesson->get( 'order' );

--- a/tests/unit-tests/server/class-llms-rest-test-sections.php
+++ b/tests/unit-tests/server/class-llms-rest-test-sections.php
@@ -405,12 +405,17 @@ class LLMS_REST_Test_Sections extends LLMS_REST_Unit_Test_Case_Posts {
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.7 Fixed expected 'order' field, added expected 'parent_id'.
+	 * @since [version] Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
+	 *
+	 * @param array           $expected  Array of expected properties.
+	 * @param LLMS_Post_Model $llms_post Instance of LLMS_Post_Model.
+	 * @return array
 	 */
 	protected function filter_expected_fields( $expected, $llms_post ) {
 
 		unset( $expected['content'] );
-		$expected[ 'order' ] = $llms_post->get('order');
-		$expected[ 'parent_id' ] = $llms_post->get_parent_course();
+		$expected['order']     = $llms_post->get( 'order' );
+		$expected['parent_id'] = $llms_post->get( 'parent_course' );
 
 		return $expected;
 


### PR DESCRIPTION
## Description
Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.

## How has this been tested?
Unable to run at this time.

After running `composer update`, removing `tmp` and running `tests-install`, I get
`Error: Looks like you're using PHPUnit 9.5.11. WordPress requires at least PHPUnit 5.7.21 and is currently only compatible with PHPUnit up to 7.x.`.

## Types of changes
Compatibility fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

