### PR TITLE
Use of deprecated LLMS_Abstract_Query items

### DIFF
--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -159,15 +159,15 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 *
 	 * @since 1.0.0-beta.7
 	 *
-	 * @param obj             $query Objects query result.
+	 * @param WP_Query        $query    Objects query result returned by {@see LLMS_REST_Posts_Controller::get_objects_query()}.
 	 * @param array           $prepared Array of collection arguments.
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request $request  Request object.
 	 * @return array {
 	 *     Array of pagination information.
 	 *
-	 *     @type int $current_page Current page number.
+	 *     @type int $current_page  Current page number.
 	 *     @type int $total_results Total number of results.
-	 *     @type int $total_pages Total number of results pages.
+	 *     @type int $total_pages   Total number of results pages.
 	 * }
 	 */
 	protected function get_pagination_data_from_query( $query, $prepared, $request ) {

--- a/includes/abstracts/class-llms-rest-users-controller.php
+++ b/includes/abstracts/class-llms-rest-users-controller.php
@@ -489,11 +489,11 @@ abstract class LLMS_REST_Users_Controller extends LLMS_Rest_Controller {
 	}
 
 	/**
-	 * Retrieve pagination information from an objects query
+	 * Retrieve pagination information from an objects query.
 	 *
 	 * @since 1.0.0-beta.1
 	 *
-	 * @param obj             $query    Objects query result.
+	 * @param WP_User_Query   $query    Objects query result returned by {@see LLMS_REST_Users_Controller::get_objects_query()}.
 	 * @param array           $prepared Array of collection arguments.
 	 * @param WP_REST_Request $request  Request object.
 	 * @return array {

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.14
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -279,6 +279,7 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 * Retrieve pagination information from an objects query.
 	 *
 	 * @since 1.0.0-beta.7
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @param obj             $query Objects query result.
 	 * @param array           $prepared Array of collection arguments.
@@ -293,9 +294,9 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 */
 	protected function get_pagination_data_from_query( $query, $prepared, $request ) {
 
-		$total_results = (int) $query->found_results;
+		$total_results = (int) $query->get_found_results();
 		$current_page  = isset( $prepared['page'] ) ? (int) $prepared['page'] : 1;
-		$total_pages   = (int) $query->max_pages;
+		$total_pages   = (int) $query->get_max_pages();
 
 		return compact( 'current_page', 'total_results', 'total_pages' );
 

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -281,15 +281,15 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.7
 	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
-	 * @param obj             $query Objects query result.
-	 * @param array           $prepared Array of collection arguments.
-	 * @param WP_REST_Request $request Request object.
+	 * @param LLMS_REST_API_Keys_Query $query    Objects query result returned by {@see LLMS_REST_API_Keys_Controller::get_objects_query()}.
+	 * @param array                    $prepared Array of collection arguments.
+	 * @param WP_REST_Request          $request  Request object.
 	 * @return array {
 	 *     Array of pagination information.
 	 *
-	 *     @type int $current_page Current page number.
+	 *     @type int $current_page  Current page number.
 	 *     @type int $total_results Total number of results.
-	 *     @type int $total_pages Total number of results pages.
+	 *     @type int $total_pages   Total number of results pages.
 	 * }
 	 */
 	protected function get_pagination_data_from_query( $query, $prepared, $request ) {

--- a/includes/server/class-llms-rest-enrollments-controller.php
+++ b/includes/server/class-llms-rest-enrollments-controller.php
@@ -768,15 +768,15 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 	 *
 	 * @since 1.0.0-beta.7
 	 *
-	 * @param obj             $query Objects query result.
+	 * @param stdClass        $query    Objects query result returned by {@see LLMS_REST_Enrollments_Controller::get_objects_query()}.
 	 * @param array           $prepared Array of collection arguments.
-	 * @param WP_REST_Request $request Request object.
+	 * @param WP_REST_Request $request  Request object.
 	 * @return array {
 	 *     Array of pagination information.
 	 *
-	 *     @type int $current_page Current page number.
+	 *     @type int $current_page  Current page number.
 	 *     @type int $total_results Total number of results.
-	 *     @type int $total_pages Total number of results pages.
+	 *     @type int $total_pages   Total number of results pages.
 	 * }
 	 */
 	protected function get_pagination_data_from_query( $query, $prepared, $request ) {
@@ -860,16 +860,16 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 	}
 
 	/**
-	 * Get enrollments query
+	 * Get enrollments query.
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.4 Enrollment's post_id and student_id casted to integer.
-	 * @since 1.0.0-beta.10 Added subquery to retrive the enrollments trigger.
+	 * @since 1.0.0-beta.10 Added subquery to retrieve the enrollments trigger.
 	 * @since 1.0.0-beta.18 Fixed wrong trigger retrieved when multiple trigger were present for the same user,post pair.
 	 *
 	 * @param  array           $query_args Array of collection arguments.
-	 * @param  WP_REST_Request $request    Optional. Full details about the request. Defaut null.
-	 * @return object An object with two fields: items an array of OBJECT result of the query; found_reults the total found items
+	 * @param  WP_REST_Request $request    Optional. Full details about the request. Default null.
+	 * @return stdClass An object with two fields: 'items' an array of OBJECT result of the query; 'found_results' the total found items.
 	 */
 	protected function get_objects_query( $query_args, $request = null ) {
 

--- a/includes/server/class-llms-rest-webhooks-controller.php
+++ b/includes/server/class-llms-rest-webhooks-controller.php
@@ -247,15 +247,15 @@ class LLMS_REST_Webhooks_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.3
 	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
-	 * @param obj             $query Objects query result.
-	 * @param array           $prepared Array of collection arguments.
-	 * @param WP_REST_Request $request Request object.
+	 * @param LLMS_REST_Webhooks_Query $query    Objects query result returned by {@see LLMS_REST_Webhooks_Controller::get_objects_query()}.
+	 * @param array                    $prepared Array of collection arguments.
+	 * @param WP_REST_Request          $request  Request object.
 	 * @return array {
 	 *     Array of pagination information.
 	 *
-	 *     @type int $current_page Current page number.
+	 *     @type int $current_page  Current page number.
 	 *     @type int $total_results Total number of results.
-	 *     @type int $total_pages Total number of results pages.
+	 *     @type int $total_pages   Total number of results pages.
 	 * }
 	 */
 	protected function get_pagination_data_from_query( $query, $prepared, $request ) {
@@ -294,8 +294,8 @@ class LLMS_REST_Webhooks_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.3
 	 *
 	 * @param array           $prepared Array of collection arguments.
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_User_Query
+	 * @param WP_REST_Request $request  Request object.
+	 * @return LLMS_REST_Webhooks_Query
 	 */
 	protected function get_objects_query( $prepared, $request ) {
 

--- a/includes/server/class-llms-rest-webhooks-controller.php
+++ b/includes/server/class-llms-rest-webhooks-controller.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.3
- * @version 1.0.0-beta.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -245,6 +245,7 @@ class LLMS_REST_Webhooks_Controller extends LLMS_REST_Controller {
 	 * Retrieve pagination information from an objects query.
 	 *
 	 * @since 1.0.0-beta.3
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @param obj             $query Objects query result.
 	 * @param array           $prepared Array of collection arguments.
@@ -261,8 +262,8 @@ class LLMS_REST_Webhooks_Controller extends LLMS_REST_Controller {
 
 		return array(
 			'current_page'  => $query->get( 'page' ),
-			'total_results' => $query->found_results,
-			'total_pages'   => $query->max_pages,
+			'total_results' => $query->get_found_results(),
+			'total_pages'   => $query->get_max_pages(),
 		);
 
 	}

--- a/lifterlms-rest.php
+++ b/lifterlms-rest.php
@@ -17,7 +17,7 @@
  * Domain Path: /i18n
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Requires LifterLMS: 3.32.0
+ * Requires LifterLMS: 6.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -60,7 +60,7 @@ if ( ! class_exists( 'LifterLMS_REST_API' ) ) {
 	 *
 	 * @since 1.0.0-beta.1
 	 *
-	 * @return LLMS_REST_API
+	 * @return LifterLMS_REST_API
 	 */
 	function LLMS_REST_API() {
 		return LifterLMS_REST_API::instance();

--- a/tests/unit-tests/class-llms-rest-test-api-keys-query.php
+++ b/tests/unit-tests/class-llms-rest-test-api-keys-query.php
@@ -59,6 +59,7 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test the include and exclude arguments.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -73,13 +74,13 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 		$query = new LLMS_REST_API_Keys_Query( array(
 			'include' => $ids,
 		) );
-		$this->assertEquals( 5, $query->found_results );
+		$this->assertEquals( 5, $query->get_found_results() );
 		$this->assertEquals( $ids, wp_list_pluck( $query->get_results(), 'id' ) );
 
 		$query = new LLMS_REST_API_Keys_Query( array(
 			'exclude' => $ids,
 		) );
-		$this->assertEquals( 5, $query->found_results );
+		$this->assertEquals( 5, $query->get_found_results() );
 		$this->assertEquals( range( 6, 10 ), wp_list_pluck( $query->get_results(), 'id' ) );
 
 	}
@@ -88,6 +89,7 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test pagination of query results.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -97,8 +99,8 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 
 		$query = new LLMS_REST_API_Keys_Query( array() );
 		$this->assertEquals( 10, count( $query->get_results() ) );
-		$this->assertEquals( 25, $query->found_results );
-		$this->assertEquals( 3, $query->max_pages );
+		$this->assertEquals( 25, $query->get_found_results() );
+		$this->assertEquals( 3, $query->get_max_pages() );
 		$this->assertEquals( range( 1, 10 ), wp_list_pluck( $query->get_results(), 'id' ) );
 		$this->assertTrue( $query->is_first_page() );
 
@@ -115,6 +117,7 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test the permissions arguments.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -125,12 +128,12 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 		$this->create_many_api_keys( 5, 'write' );
 
 		$query = new LLMS_REST_API_Keys_Query( array() );
-		$this->assertEquals( 15, $query->found_results );
+		$this->assertEquals( 15, $query->get_found_results() );
 
 		foreach ( array_keys( LLMS_REST_API()->keys()->get_permissions() ) as $pem ) {
 
 			$query = new LLMS_REST_API_Keys_Query( array( 'permissions' => $pem ) );
-			$this->assertEquals( 5, $query->found_results );
+			$this->assertEquals( 5, $query->get_found_results() );
 
 		}
 
@@ -233,6 +236,7 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test the users include and exclude arguments.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -247,13 +251,13 @@ class LLMS_REST_Test_API_Keys_Query extends LLMS_REST_Unit_Test_Case_Base {
 			'user' => $uid,
 		) );
 		$res_1 = wp_list_pluck( $query->get_results(), 'id' );
-		$this->assertEquals( 5, $query->found_results );
+		$this->assertEquals( 5, $query->get_found_results() );
 
 		$query = new LLMS_REST_API_Keys_Query( array(
 			'user_not_in' => $uid,
 		) );
 		$res_2 = wp_list_pluck( $query->get_results(), 'id' );
-		$this->assertEquals( 5, $query->found_results );
+		$this->assertEquals( 5, $query->get_found_results() );
 		$this->assertTrue( $res_1 !== $res_2 );
 
 	}

--- a/tests/unit-tests/class-llms-rest-test-webhooks-query.php
+++ b/tests/unit-tests/class-llms-rest-test-webhooks-query.php
@@ -60,6 +60,7 @@ class LLMS_REST_Test_Webhooks_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test the include and exclude arguments.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -74,13 +75,13 @@ class LLMS_REST_Test_Webhooks_Query extends LLMS_REST_Unit_Test_Case_Base {
 		$query = new LLMS_REST_Webhooks_Query( array(
 			'include' => $ids,
 		) );
-		$this->assertEquals( 5, $query->found_results );
+		$this->assertEquals( 5, $query->get_found_results() );
 		$this->assertEquals( $ids, wp_list_pluck( $query->get_results(), 'id' ) );
 
 		$query = new LLMS_REST_Webhooks_Query( array(
 			'exclude' => $ids,
 		) );
-		$this->assertEquals( 5, $query->found_results );
+		$this->assertEquals( 5, $query->get_found_results() );
 		$this->assertEquals( range( 6, 10 ), wp_list_pluck( $query->get_results(), 'id' ) );
 
 	}
@@ -89,6 +90,7 @@ class LLMS_REST_Test_Webhooks_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test pagination of query results.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -98,8 +100,8 @@ class LLMS_REST_Test_Webhooks_Query extends LLMS_REST_Unit_Test_Case_Base {
 
 		$query = new LLMS_REST_Webhooks_Query( array() );
 		$this->assertEquals( 10, count( $query->get_results() ) );
-		$this->assertEquals( 25, $query->found_results );
-		$this->assertEquals( 3, $query->max_pages );
+		$this->assertEquals( 25, $query->get_found_results() );
+		$this->assertEquals( 3, $query->get_max_pages() );
 		$this->assertEquals( range( 1, 10 ), wp_list_pluck( $query->get_results(), 'id' ) );
 		$this->assertTrue( $query->is_first_page() );
 
@@ -116,6 +118,7 @@ class LLMS_REST_Test_Webhooks_Query extends LLMS_REST_Unit_Test_Case_Base {
 	 * Test the status filter arguments.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
 	 *
 	 * @return void
 	 */
@@ -126,12 +129,12 @@ class LLMS_REST_Test_Webhooks_Query extends LLMS_REST_Unit_Test_Case_Base {
 		$this->create_many_webhooks( 5, 'paused' );
 
 		$query = new LLMS_REST_Webhooks_Query( array() );
-		$this->assertEquals( 15, $query->found_results );
+		$this->assertEquals( 15, $query->get_found_results() );
 
 		foreach ( array_keys( LLMS_REST_API()->webhooks()->get_statuses() ) as $status ) {
 
 			$query = new LLMS_REST_Webhooks_Query( array( 'status' => $status ) );
-			$this->assertEquals( 5, $query->found_results );
+			$this->assertEquals( 5, $query->get_found_results() );
 
 		}
 


### PR DESCRIPTION
## Description
Fixed access of protected LLMS_Abstract_Query properties.

## How has this been tested?
Only unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

