### PR TITLE
Stop returning an error when updating resources properties with a new value equal to the saved one

### DIFF
--- a/.changelogs/issue_222.yml
+++ b/.changelogs/issue_222.yml
@@ -2,5 +2,5 @@ significance: patch
 type: changed
 links:
   - "#222"
-entry: Stop returning an error when updating resources properties with a new
+entry: Stop returning an error when updating resource properties with a
   value equal to the saved one.

--- a/.changelogs/issue_222.yml
+++ b/.changelogs/issue_222.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: changed
+links:
+  - "#222"
+entry: Stop returning an error when updating resources properties with a new
+  value equal to the saved one.

--- a/.changelogs/issue_222.yml
+++ b/.changelogs/issue_222.yml
@@ -2,5 +2,6 @@ significance: patch
 type: changed
 links:
   - "#222"
+  - "#289"
 entry: Stop returning an error when updating resource properties with a
   value equal to the saved one.

--- a/class-lifterlms-rest-api.php
+++ b/class-lifterlms-rest-api.php
@@ -197,15 +197,16 @@ final class LifterLMS_REST_API {
 	 *                     just after all the db tables are created (init 5),
 	 *                     to avoid PHP warnings on first plugin activation.
 	 * @since 1.0.0-beta.22 Bump minimum required version to 6.0.0-alpha.1.
-	 *                     Use `llms()` in favor of deprecated `LLMS()`.
+	 *                      Use `llms()` in favor of deprecated `LLMS()`.
 	 * @since [version] Perform some db clean-up on user deletion.
+	 *                      Bump minimum required version to 6.5.0.
 	 *
 	 * @return void
 	 */
 	public function init() {
 
 		// Only load if we have the minimum LifterLMS version installed & activated.
-		if ( ! function_exists( 'llms' ) || version_compare( '6.0.0-alpha.1', llms()->version, '>' ) ) {
+		if ( ! function_exists( 'llms' ) || version_compare( '6.5.0-alpha.1', llms()->version, '>' ) ) {
 			return;
 		}
 

--- a/class-lifterlms-rest-api.php
+++ b/class-lifterlms-rest-api.php
@@ -206,7 +206,7 @@ final class LifterLMS_REST_API {
 	public function init() {
 
 		// Only load if we have the minimum LifterLMS version installed & activated.
-		if ( ! function_exists( 'llms' ) || version_compare( '6.5.0-alpha.1', llms()->version, '>' ) ) {
+		if ( ! function_exists( 'llms' ) || version_compare( '6.5.0', llms()->version, '>' ) ) {
 			return;
 		}
 

--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.21
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,12 +23,12 @@ defined( 'ABSPATH' ) || exit;
  *                     Fix wp:featured_media link, we don't expose any embeddable field.
  *                     Also `self` and `collection` links prepared in the parent class.
  *                     Added `"llms_rest_insert_{$this->post_type}"` and `"llms_rest_insert_{$this->post_type}"` action hooks:
- *                     fired after inserting/updateing an llms post into the database.
+ *                     fired after inserting/updating an llms post into the database.
  * @since 1.0.0-beta.8 Return links to those taxonomies which have an accessible rest route.
  *                     Initialize `$prepared_item` array before adding values to it.
  * @since 1.0.0-beta.9 Implemented a generic way to create and get an llms post object instance given a `post_type`.
  *                     In `get_objects_from_query()` avoid performing an additional query, just return the already retrieved posts.
- *                     Removed `"llms_rest_{$this->post_type}_filters_removed_for_reponse"` filter hooks,
+ *                     Removed `"llms_rest_{$this->post_type}_filters_removed_for_response"` filter hooks,
  *                     `"llms_rest_{$this->post_type}_filters_removed_for_response"` added.
  * @since 1.0.0-beta.11 Fixed `"llms_rest_insert_{$this->post_type}"` and `"llms_rest_insert_{$this->post_type}"` action hooks fourth param:
  *                     must be false when updating.
@@ -220,6 +220,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.7 Added `"llms_rest_insert_{$this->post_type}"` and `"llms_rest_insert_{$this->post_type}"` action hooks:
 	 *                     fired after inserting/uodateing an llms post into the database.
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -261,7 +262,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 
 		// Set all the other properties.
 		// TODO: maybe we want to filter the post properties that have already been inserted before.
-		$set_bulk_result = $object->set_bulk( $prepared_item, true );
+		$set_bulk_result = $object->set_bulk( $prepared_item, true, true );
 		if ( is_wp_error( $set_bulk_result ) ) {
 
 			if ( 'db_update_error' === $set_bulk_result->get_error_code() ) {
@@ -513,6 +514,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 *                     fired after inserting/uodateing an llms post into the database.
 	 * @since 1.0.0-beta.11 Fixed `"llms_rest_insert_{$this->post_type}"` and `"llms_rest_insert_{$this->post_type}"` action hooks fourth param:
 	 *                     must be false when updating.
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -529,7 +531,7 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 			return $prepared_item;
 		}
 
-		$update_result = empty( array_diff_key( $prepared_item, array_flip( array( 'id' ) ) ) ) ? false : $object->set_bulk( $prepared_item, true );
+		$update_result = empty( array_diff_key( $prepared_item, array_flip( array( 'id' ) ) ) ) ? false : $object->set_bulk( $prepared_item, true, true );
 		if ( is_wp_error( $update_result ) ) {
 
 			if ( 'db_update_error' === $update_result->get_error_code() ) {

--- a/includes/server/class-llms-rest-access-plans-controller.php
+++ b/includes/server/class-llms-rest-access-plans-controller.php
@@ -559,10 +559,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 			// If availability restrictions supplied is not empty, set `availability` to 'members'.
 			$to_set['availability'] = ! empty( $to_set['availability_restrictions'] ) ? 'members' : 'open';
 		}
-		// Only set availaibility if different from the previous one, because if equal they will produce an error (see update_post_meta()).
-		if ( isset( $to_set['availability'] ) && $to_set['availability'] === $current_availability ) {
-			unset( $to_set['availability'] );
-		}
 
 		// Redirect forced.
 		if ( ! empty( $schema['properties']['redirect_forced'] ) && isset( $request['redirect_forced'] ) ) {
@@ -636,6 +632,7 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 	 *
 	 * @since 1.0.0-beta.18
 	 * @since 1.0.0-beta-24 Cast `price` property to float.
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param array $to_set      Array of properties to be set.
 	 * @param array $saved_props Array of LLMS_Access_Plan properties as saved in the db.
@@ -666,15 +663,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 			$subordinate_props['on_sale']     = 'no';
 			$subordinate_props['trial_offer'] = 'no';
 
-		}
-
-		if ( ! $creating ) { // Remove already set properties.
-
-			foreach ( $subordinate_props as $_prop => $value ) {
-				if ( isset( $saved_props[ $_prop ] ) && $saved_props[ $_prop ] === $value ) {
-					unset( $subordinate_props[ $_prop ] );
-				}
-			}
 		}
 
 		$to_set = array_merge( $to_set, $subordinate_props );

--- a/includes/server/class-llms-rest-access-plans-controller.php
+++ b/includes/server/class-llms-rest-access-plans-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.18
- * @version 1.0.0-beta-24
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -447,6 +447,7 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 	 * @since 1.0.0-beta-24 Fixed reference to a non-existent schema property: visibiliy in place of visibility.
 	 *                      Fixed issue that prevented updating the access plan `redirect_forced` property.
 	 *                      Better handling of the availability_restrictions.
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param LLMS_Access_Plan $access_plan   LLMS Access Plan instance.
 	 * @param WP_REST_Request  $request       Full details about the request.
@@ -594,7 +595,7 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 
 		// Set bulk.
 		if ( ! empty( $to_set ) ) {
-			$update = $access_plan->set_bulk( $to_set, true );
+			$update = $access_plan->set_bulk( $to_set, true, true );
 			if ( is_wp_error( $update ) ) {
 				$error = $update;
 			}

--- a/includes/server/class-llms-rest-access-plans-controller.php
+++ b/includes/server/class-llms-rest-access-plans-controller.php
@@ -546,14 +546,10 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		// Availability restrictions.
-		$current_availability              = $access_plan->get( 'availability' );
-		$current_availability_restrictions = $access_plan->get( 'availability_restrictions' );
 		// If access plan related post type is not a course, set availability to 'open' and clean the `availability_restrictions` array.
 		if ( 'course' !== $access_plan->get_product_type() ) {
 			$to_set['availability'] = 'open';
-			if ( ! empty( $current_availability_restrictions ) ) {
-				$to_set['availability_restrictions'] = array();
-			}
+			$to_set['availability_restrictions'] = array();
 		} elseif ( ! empty( $schema['properties']['availability_restrictions'] ) && isset( $request['availability_restrictions'] ) ) {
 			$to_set['availability_restrictions'] = $request['availability_restrictions'];
 			// If availability restrictions supplied is not empty, set `availability` to 'members'.

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.18
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -798,6 +798,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 	 *                     so to instruct it to return a WP_Error on failure.
 	 * @since 1.0.0-beta.9 Use `WP_Error::$errors` in place of `WP_Error::has_errors()` to support WordPress version prior to 5.1.
 	 *                     Also made sure course's `instructor` is at least set as the post author.
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param LLMS_Course     $course        LLMS_Course instance.
 	 * @param WP_REST_Request $request       Full details about the request.
@@ -978,7 +979,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 
 		// Set bulk.
 		if ( ! empty( $to_set ) ) {
-			$update = $course->set_bulk( $to_set, true );
+			$update = $course->set_bulk( $to_set, true, true );
 			if ( is_wp_error( $update ) ) {
 				$error = $update;
 			}

--- a/includes/server/class-llms-rest-courses-controller.php
+++ b/includes/server/class-llms-rest-courses-controller.php
@@ -929,7 +929,7 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			}
 		}
 
-		// Enrolmments opens/closes messages.
+		// Enrollments opens/closes messages.
 		if ( ! empty( $schema['properties']['enrollment_opens_message'] ) && isset( $request['enrollment_opens_message'] ) ) {
 			if ( is_string( $request['enrollment_opens_message'] ) ) {
 				$to_set['enrollment_opens_message'] = $request['enrollment_opens_message'];
@@ -962,17 +962,6 @@ class LLMS_REST_Courses_Controller extends LLMS_REST_Posts_Controller {
 			foreach ( $_to_expand_props as $prop ) {
 				if ( ! empty( $to_set[ $prop ] ) ) {
 					$to_set[ $prop ] = str_replace( '{{course_id}}', $course_id, $to_set[ $prop ] );
-				}
-			}
-		} else { // Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
-			$_props = array(
-				'time_period',
-				'enrollment_period',
-				'has_prerequisite',
-			);
-			foreach ( $_props as $_prop ) {
-				if ( isset( $to_set[ $_prop ] ) && $to_set[ $_prop ] === $course->get( $_prop ) ) {
-					unset( $to_set[ $_prop ] );
 				}
 			}
 		}

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.23
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -257,6 +257,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	 * @since 1.0.0-beta.7
 	 * @since 1.0.0-beta.8 Call `set_bulk()` llms post method passing `true` as second parameter,
 	 *                     so to instruct it to return a WP_Error on failure.
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param LLMS_Lesson     $lesson        LLMS_Lesson instance.
 	 * @param WP_REST_Request $request       Full details about the request.
@@ -295,7 +296,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 
 		// Set bulk.
 		if ( ! empty( $to_set ) ) {
-			$update = $lesson->set_bulk( $to_set, true );
+			$update = $lesson->set_bulk( $to_set, true, true );
 			if ( is_wp_error( $update ) ) {
 				$error = $update;
 			}

--- a/includes/server/class-llms-rest-memberships-controller.php
+++ b/includes/server/class-llms-rest-memberships-controller.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * REST Memberships Controller.
+ * REST Memberships Controller
  *
  * @package LifterLMS_REST/Classes/Controllers
  *
  * @since 1.0.0-beta.9
- * @version 1.0.0-beta.14
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -567,6 +567,7 @@ class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
 	 * This method should be used for membership properties that require the membership id in order to be saved in the database.
 	 *
 	 * @since 1.0.0-beta.9
+	 * @since [version] Allow updating meta with the same value as the stored one.
 	 *
 	 * @param LLMS_Membership $membership    LLMS_Membership instance.
 	 * @param WP_REST_Request $request       Full details about the request.
@@ -662,7 +663,7 @@ class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
 
 		// Set bulk.
 		if ( ! empty( $to_set ) ) {
-			$update = $membership->set_bulk( $to_set, true );
+			$update = $membership->set_bulk( $to_set, true, true );
 			if ( is_wp_error( $update ) ) {
 				$error = $update;
 			}

--- a/includes/server/class-llms-rest-memberships-controller.php
+++ b/includes/server/class-llms-rest-memberships-controller.php
@@ -650,15 +650,6 @@ class LLMS_REST_Memberships_Controller extends LLMS_REST_Posts_Controller {
 					$to_set[ $prop ] = str_replace( '{{membership_id}}', $membership_id, $to_set[ $prop ] );
 				}
 			}
-		} else { // Needed until the following will be implemented: https://github.com/gocodebox/lifterlms/issues/908.
-			$_props = array(
-				'restriction_add_notice',
-			);
-			foreach ( $_props as $_prop ) {
-				if ( isset( $to_set[ $_prop ] ) && $to_set[ $_prop ] === $membership->get( $_prop ) ) {
-					unset( $to_set[ $_prop ] );
-				}
-			}
 		}
 
 		// Set bulk.

--- a/lifterlms-rest.php
+++ b/lifterlms-rest.php
@@ -17,7 +17,7 @@
  * Domain Path: /i18n
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Requires LifterLMS: 6.0.0
+ * Requires LifterLMS: 6.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/tests/unit-tests/server/class-llms-rest-test-access-plans.php
+++ b/tests/unit-tests/server/class-llms-rest-test-access-plans.php
@@ -11,7 +11,7 @@
  * @since 1.0.0-beta-24 Added tests on updating a free access plan.
  *                      Added tests on `availability_restrictions`.
  *                      Added tests on updating access plan of a product with access plans limit reached.
- * @version 1.0.0-beta-24
+ * @since [version] Added protected method `create_post_resource()` (override).
  */
 class LLMS_REST_Test_Access_Plans extends LLMS_REST_Unit_Test_Case_Posts {
 
@@ -138,7 +138,7 @@ class LLMS_REST_Test_Access_Plans extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
-	 * Test list access plans pagination success
+	 * Test list access plans pagination success.
 	 *
 	 * @since 1.0.0-beta.18
 	 *
@@ -1270,6 +1270,31 @@ class LLMS_REST_Test_Access_Plans extends LLMS_REST_Unit_Test_Case_Posts {
 			$response->get_links()['post'][0]['href']
 		);
 
+
+	}
+
+	/**
+	 * Create a resource for this post type.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $params Array of request params.
+	 * @return WP_Post
+	 */
+	protected function create_post_resource( $params = array() ) {
+
+		$course_id = $this->factory->course->create(
+			array(
+				'sections' => 0,
+			)
+		);
+
+		return parent::create_post_resource(
+			array(
+				'price'   => 0,
+				'post_id' => $course_id,
+			)
+		);
 
 	}
 

--- a/tests/unit-tests/server/class-llms-rest-test-courses.php
+++ b/tests/unit-tests/server/class-llms-rest-test-courses.php
@@ -1253,11 +1253,11 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 		$this->assertEquals( $update_data['date_created'], $res_data['date_created'] );
 		$this->assertEquals( $update_data['status'], $res_data['status'] );
 
-		// check the course has no prerequisites.
+		// Check the course has no prerequisites.
 		$course = new LLMS_Course( $res_data['id'] );
 		$this->assertFalse( $course->has_prerequisite() );
 
-		// create a course prerequisite.
+		// Create a course prerequisite.
 		$prerequisite_id       = $this->factory->course->create();
 		$track                 = wp_insert_term( 'mock track', 'course_track' );
 		$prerequisite_track_id = $track['term_id'];
@@ -1279,7 +1279,7 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 
 		$res_data = $response->get_data();
 
-		// check the course has prerequisites.
+		// Check the course has prerequisites.
 		$course = new LLMS_Course( $res_data['id'] );
 		$this->assertTrue( $course->has_prerequisite() );
 		$this->assertTrue( $course->has_prerequisite( 'course' ) );

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -708,6 +708,34 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test updating the lessons parent section.
+	 *
+	 * @since [version]
+	 *
+	 * @link https://github.com/gocodebox/lifterlms-rest/issues/289
+	 *
+	 * @return void
+	 */
+	public function test_update_parent_section() {
+
+		// Setup.
+		wp_set_current_user( $this->user_allowed );
+		$course = $this->factory->course->create_and_get();
+
+		// Get IDs for the first lesson and the second section.
+		$sections     = $course->get_sections();
+		$section_2_id = $sections[1]->get( 'id' );
+		$lesson_1_id  = $sections[0]->get_lessons( 'ids' )[0];
+
+		// Update the lesson's parent section.
+		$route    = "{$this->route}/{$lesson_1_id}";
+		$response = $this->perform_mock_request( 'POST', $route, array( 'parent_id' => $section_2_id ) );
+		$this->assertFalse( $response->is_error() );
+		$this->assertEquals( $section_2_id, $response->get_data()['parent_id'] );
+
+	}
+
+	/**
 	 * Create a resource for this post type.
 	 *
 	 * @since [version]

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -9,6 +9,7 @@
  *
  * @since 1.0.0-beta.7
  * @since 1.0.0-beta.15 Added tests on setting lesson parents.
+ * @since [version] Added protected method `create_post_resource()` (override).
  */
 class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 
@@ -703,6 +704,32 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 			$this->assertEquals( $expected_link_rels, array_keys( $response->get_links() ) );
 
 		}
+
+	}
+
+	/**
+	 * Create a resource for this post type.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $params Array of request params.
+	 * @return WP_Post
+	 */
+	protected function create_post_resource( $params = array() ) {
+
+		$course = $this->factory->course->create_and_get(
+			array(
+				'sections' => 1,
+				'lessons'  => 0,
+			)
+		);
+
+		return parent::create_post_resource(
+			array(
+				'parent_id' => $course->get_sections('ids')[0],
+				'course_id' => $course->get('id'),
+			)
+		);
 
 	}
 

--- a/tests/unit-tests/server/class-llms-rest-test-sections.php
+++ b/tests/unit-tests/server/class-llms-rest-test-sections.php
@@ -9,8 +9,8 @@
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.7 Added links test, block migration forcing and db cleanup moved to LLMS_REST_Unit_Test_Case_Posts::set_up(),
- *                  fixed sections fields checks when retrieving the collection.
- * @version 1.0.0-beta.7
+ *                     fixed sections fields checks when retrieving the collection.
+ * @since [version] Added protected method `create_post_resource()` (override).
  */
 class LLMS_REST_Test_Sections extends LLMS_REST_Unit_Test_Case_Posts {
 
@@ -397,6 +397,30 @@ class LLMS_REST_Test_Sections extends LLMS_REST_Unit_Test_Case_Posts {
 
 		$new_sec_controller = new LLMS_REST_Sections_Controller( '' );
 		$this->assertNull( $new_sec_controller->get_content_controller() );
+
+	}
+
+	/**
+	 * Create a resource for this post type.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $params Array of request params.
+	 * @return WP_Post
+	 */
+	protected function create_post_resource( $params = array() ) {
+
+		$course_id = $this->factory->course->create(
+			array(
+				'sections' => 0,
+			)
+		);
+
+		return parent::create_post_resource(
+			array(
+				'parent_id' => $course_id,
+			)
+		);
 
 	}
 


### PR DESCRIPTION
## Description
Fixes #222 
Fixes #289 
Requires https://github.com/gocodebox/lifterlms/pull/2129

## How has this been tested?
existing unit tests and new unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

