### PR TITLE
Fix how a change to the parent course ID is checked in prepare_item_f…

### DIFF
--- a/.changelogs/issue_289.yml
+++ b/.changelogs/issue_289.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#289"
+entry: Fixed an issue that caused an error when moving a lesson from one section
+  to another.

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -707,6 +707,33 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test updating the lessons parent section.
+	 *
+	 * @since [version]
+	 *
+	 * @link https://github.com/gocodebox/lifterlms-rest/issues/289
+	 *
+	 * @return void
+	 */
+	public function test_update_parent_section() {
+
+		// Setup.
+		wp_set_current_user( $this->user_allowed );
+		$course = $this->factory->course->create_and_get();
+
+		// Get IDs for the first lesson and the second section.
+		$sections     = $course->get_sections();
+		$section_2_id = $sections[1]->get( 'id' );
+		$lesson_1_id  = $sections[0]->get_lessons( 'ids' )[0];
+
+		// Update the lesson's parent section.
+		$route    = "$this->route/$lesson_1_id";
+		$response = $this->perform_mock_request( 'POST', $route, array( 'parent_id' => $section_2_id ) );
+		$this->assertFalse( $response->is_error() );
+		$this->assertEquals( $section_2_id, $response->get_data()['parent_id'] );
+	}
+
+	/**
 	 * Override.
 	 *
 	 * @since 1.0.0-beta.7


### PR DESCRIPTION
## Description
Fixed how a change to a lesson's parent course ID is checked. It was using an undefined variable.

Fixes #289.

## How has this been tested?
Manually and with a new unit test.

## Types of changes
Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

