### PR TITLE
Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant and `strftime()`

### DIFF
--- a/.changelogs/compatitbility-php81-1.yml
+++ b/.changelogs/compatitbility-php81-1.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Replaced use of deprecated `strftime()`.

--- a/.changelogs/compatitbility-php81.yml
+++ b/.changelogs/compatitbility-php81.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant.

--- a/includes/admin/class-llms-rest-admin-form-controller.php
+++ b/includes/admin/class-llms-rest-admin-form-controller.php
@@ -105,7 +105,7 @@ class LLMS_REST_Admin_Form_Controller {
 			'name'         => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_name' ),
 			'status'       => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_status' ),
 			'topic'        => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_topic' ),
-			'delivery_url' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_delivery_url' ),
+			'delivery_url' => llms_filter_input( INPUT_POST, 'llms_rest_webhook_delivery_url', FILTER_SANITIZE_URL ),
 			'secret'       => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_secret' ),
 		);
 

--- a/includes/admin/class-llms-rest-admin-form-controller.php
+++ b/includes/admin/class-llms-rest-admin-form-controller.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Handle admin form submissions.
+ * Handle admin form submissions
  *
  * @package  LifterLMS_REST/Admin/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_REST_Admin_Form_Controller class..
+ * LLMS_REST_Admin_Form_Controller class.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.3 Added API credential download methods.
@@ -92,24 +92,25 @@ class LLMS_REST_Admin_Form_Controller {
 	}
 
 	/**
-	 * Handle creating/updating a webhook via admin interfaces
+	 * Handle creating/updating a webhook via admin interfaces.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant.
 	 *
 	 * @return true|void|WP_Error true on update success, void (redirect) on creation success, WP_Error on failure.
 	 */
 	protected function handle_webhook_upsert() {
 
 		$data = array(
-			'name'         => llms_filter_input( INPUT_POST, 'llms_rest_webhook_name', FILTER_SANITIZE_STRING ),
-			'status'       => llms_filter_input( INPUT_POST, 'llms_rest_webhook_status', FILTER_SANITIZE_STRING ),
-			'topic'        => llms_filter_input( INPUT_POST, 'llms_rest_webhook_topic', FILTER_SANITIZE_STRING ),
-			'delivery_url' => llms_filter_input( INPUT_POST, 'llms_rest_webhook_delivery_url', FILTER_SANITIZE_URL ),
-			'secret'       => llms_filter_input( INPUT_POST, 'llms_rest_webhook_secret', FILTER_SANITIZE_STRING ),
+			'name'         => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_name' ),
+			'status'       => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_status' ),
+			'topic'        => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_topic' ),
+			'delivery_url' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_delivery_url' ),
+			'secret'       => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_secret' ),
 		);
 
 		if ( 'action' === $data['topic'] ) {
-			$data['topic'] .= '.' . llms_filter_input( INPUT_POST, 'llms_rest_webhook_action', FILTER_SANITIZE_STRING );
+			$data['topic'] .= '.' . llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_webhook_action' );
 		}
 
 		$hook_id = llms_filter_input( INPUT_POST, 'llms_rest_webhook_id', FILTER_SANITIZE_NUMBER_INT );
@@ -150,13 +151,14 @@ class LLMS_REST_Admin_Form_Controller {
 	 * Validates `GET` information from the credential download URL and prepares information for generating the file.
 	 *
 	 * @since 1.0.0-beta.3
+	 * @since [version] Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant.
 	 *
 	 * @return false|array
 	 */
 	protected function prepare_key_download() {
 
 		$key_id       = llms_filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
-		$consumer_key = llms_filter_input( INPUT_GET, 'ck', FILTER_SANITIZE_STRING );
+		$consumer_key = llms_filter_input_sanitize_string( INPUT_GET, 'ck' );
 
 		// return if missing required fields.
 		if ( ! $key_id || ! $consumer_key ) {

--- a/includes/admin/class-llms-rest-admin-settings-api-keys.php
+++ b/includes/admin/class-llms-rest-admin-settings-api-keys.php
@@ -5,13 +5,13 @@
  * @package LifterLMS_REST/Admin/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin Settings Page: REST API
+ * Admin Settings Page: REST API.
  *
  * @since 1.0.0-beta.1
  * @since 1.0.0-beta.3 Improve UX of key generation and updates.
@@ -257,6 +257,7 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 	 * Form handler to create a new API key.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant.
 	 *
 	 * @return LLMS_REST_API_Key|WP_Error
 	 */
@@ -264,9 +265,9 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 
 		$create = LLMS_REST_API()->keys()->create(
 			array(
-				'description' => llms_filter_input( INPUT_POST, 'llms_rest_key_description', FILTER_SANITIZE_STRING ),
-				'user_id'     => llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT ),
-				'permissions' => llms_filter_input( INPUT_POST, 'llms_rest_key_permissions', FILTER_SANITIZE_STRING ),
+				'description' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_description' ),
+				'user_id'     => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_user_id' ),
+				'permissions' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_permissions' ),
 			)
 		);
 
@@ -282,6 +283,7 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 	 * Form handler to save an API key.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant.
 	 *
 	 * @param int $key_id API Key ID.
 	 * @return LLMS_REST_API_Key|WP_Error
@@ -297,9 +299,9 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 		$update = LLMS_REST_API()->keys()->update(
 			array(
 				'id'          => $key_id,
-				'description' => llms_filter_input( INPUT_POST, 'llms_rest_key_description', FILTER_SANITIZE_STRING ),
+				'description' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_description' ),
 				'user_id'     => llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT ),
-				'permissions' => llms_filter_input( INPUT_POST, 'llms_rest_key_permissions', FILTER_SANITIZE_STRING ),
+				'permissions' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_permissions' ),
 			)
 		);
 

--- a/includes/admin/class-llms-rest-admin-settings-api-keys.php
+++ b/includes/admin/class-llms-rest-admin-settings-api-keys.php
@@ -266,7 +266,7 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 		$create = LLMS_REST_API()->keys()->create(
 			array(
 				'description' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_description' ),
-				'user_id'     => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_user_id' ),
+				'user_id'     => llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT ),
 				'permissions' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_permissions' ),
 			)
 		);

--- a/includes/class-llms-rest-authentication.php
+++ b/includes/class-llms-rest-authentication.php
@@ -186,6 +186,7 @@ class LLMS_REST_Authentication {
 	 * Locate credentials in the $_SERVER superglobal.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant.
 	 *
 	 * @param string $key_var Variable name for the consumer key.
 	 * @param string $secret_var Variable name for the consumer secret.
@@ -194,8 +195,8 @@ class LLMS_REST_Authentication {
 	private function get_credentials( $key_var, $secret_var ) {
 
 		// Use `filter_var()` instead of `llms_filter_input()` due to PHP bug with `filter_input()`: https://bugs.php.net/bug.php?id=49184.
-		$key    = isset( $_SERVER[ $key_var ] ) ? filter_var( wp_unslash( $_SERVER[ $key_var ] ), FILTER_SANITIZE_STRING ) : null;
-		$secret = isset( $_SERVER[ $secret_var ] ) ? filter_var( wp_unslash( $_SERVER[ $secret_var ] ), FILTER_SANITIZE_STRING ) : null;
+		$key    = isset( $_SERVER[ $key_var ] ) ? sanitize_text_field( filter_var( wp_unslash( $_SERVER[ $key_var ] ) ) ) : null;
+		$secret = isset( $_SERVER[ $secret_var ] ) ? sanitize_text_field( filter_var( wp_unslash( $_SERVER[ $secret_var ] ) ) ) : null;
 
 		if ( ! $key || ! $secret ) {
 			return false;

--- a/includes/class-llms-rest-webhooks.php
+++ b/includes/class-llms-rest-webhooks.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Classes
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.23
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -111,6 +111,7 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.3 Fix formatting error.
 	 * @since 1.0.0-beta.17 Remove reference to 'pending_delivery' (unused) column.
+	 * @since [version] Don't use deprecated `strftime` function.
 	 *
 	 * @return array
 	 */
@@ -122,10 +123,16 @@ class LLMS_REST_Webhooks extends LLMS_REST_Database_Resource {
 			'failure_count' => 0,
 			'user_id'       => get_current_user_id(),
 			'name'          => sprintf(
-				// Translators: %s = created date.
-				__( 'Webhook created on %s', 'lifterlms' ),
-				// Translators: Date format.
-				strftime( _x( '%b %d, %Y @ %I:%M %p', 'Webhook created on date parsed by strftime', 'lifterlms' ) ) // phpcs:disable WordPress.WP.I18n.UnorderedPlaceholdersText
+				// Translators: %1$s = created date.
+				__( 'Webhook created on %1$s', 'lifterlms' ),
+				wp_date(
+					sprintf(
+						// Translators: %1$s Date format as specified in the WordPress General Settings, %1$s Time format as specified in the WordPress General Settings.
+						_x( '%1$s @ %2$s', 'Webhook created on date parsed by wp_date', 'lifterlms' ),
+						get_option( 'date_format' ),
+						get_option( 'time_format' )
+					)
+				)
 			),
 		);
 


### PR DESCRIPTION
## Description
PHP 8.1 Compatibility.
Replaced use of the deprecated `FILTER_SANITIZE_STRING` constant and `strftime()`.

## How has this been tested?
manually and with unit tests

## Screenshots <!-- if applicable -->

## Types of changes
compatibility with 8.1

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

