### PR TITLE
Avoid fatals when searching for courses/memberships but the query post type parameter is forced to be something else

### DIFF
--- a/.changelogs/issue_299.yml
+++ b/.changelogs/issue_299.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: fixed
+links:
+  - "#299"
+entry: Avoid PHP fatal when searching for courses/memberships but the query post
+  type parameter is forced to a different post type. e.g. all post types except
+  `post` excluded from search results.

--- a/includes/abstracts/class-llms-rest-posts-controller.php
+++ b/includes/abstracts/class-llms-rest-posts-controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Abstracts
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.27
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -1706,11 +1706,17 @@ abstract class LLMS_REST_Posts_Controller extends LLMS_REST_Controller {
 	 * Checks if an llms post can be read.
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [version] Fix fatals when searching for llms post type based resources
+	 *                  but the query post type parameter is forced to be something else.
 	 *
 	 * @param LLMS_Post_Model $object The LLMS_Post_model object.
 	 * @return bool Whether the post can be read.
 	 */
 	protected function check_read_permission( $object ) {
+
+		if ( is_wp_error( $object ) ) {
+			return false;
+		}
 
 		$post_type = get_post_type_object( $this->post_type );
 		$status    = $object->get( 'status' );


### PR DESCRIPTION
## Description
Fixes #299

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

