### PR TITLE
[Fix] Payloads are not sent for all the enrollments.

### DIFF
--- a/.changelogs/missing-payload.yml
+++ b/.changelogs/missing-payload.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: dev
+links:
+  - "#2568"
+entry: Updated the proccessed flag to use the last argument of `$args`.

--- a/.changelogs/pr_2567-1.yml
+++ b/.changelogs/pr_2567-1.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: dev
+links:
+  - "#2568"
+entry: Updated the proccessed flag to use the second argument (Enrollment Object
+  ID) of `$args`.

--- a/.changelogs/pr_2567-1.yml
+++ b/.changelogs/pr_2567-1.yml
@@ -1,6 +1,0 @@
-significance: patch
-type: dev
-links:
-  - "#2568"
-entry: Updated the proccessed flag to use the second argument (Enrollment Object
-  ID) of `$args`.

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -361,7 +361,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 
 		// Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request,
 		// as it might happen with webhooks with multiple hookes defined in `LLMS_REST_Webhooks::get_hooks()`.
-		$this->processed[] = $args[0];
+		$this->processed[] = $args[2];
 
 		/**
 		 * Disable background processing of webhooks by returning a falsy

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -362,7 +362,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 
 		// Mark this hook's second argument (Enrollment Object ID) as processed to ensure it doesn't get processed again within the current request,
 		// as it might happen with webhooks with multiple hookes defined in `LLMS_REST_Webhooks::get_hooks()`.
-		$this->processed[] = $args[2];
+		$this->processed[] = $args[1];
 
 		/**
 		 * Disable background processing of webhooks by returning a falsy

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -348,7 +348,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.17 Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request.
 	 *                      And don't rely anymore on the webhook's `pending_delivery` property to achieve the same goal.
-	 * @since [version] Updated the proccessed flag to use the second argument (Enrollment Object ID) of `$args`.
+	 * @since [version] Updated the proccessed flag to use the last argument of `$args` irrespective of number of arguments.
 	 *
 	 * @param mixed ...$args Arguments from the hook.
 	 * @return int|false Timestamp of the scheduled event when the webhook is successfully scheduled.
@@ -360,9 +360,9 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 			return false;
 		}
 
-		// Mark this hook's second argument (Enrollment Object ID) as processed to ensure it doesn't get processed again within the current request,
-		// as it might happen with webhooks with multiple hookes defined in `LLMS_REST_Webhooks::get_hooks()`.
-		$this->processed[] = $args[1];
+		// Mark this hook's last argument as processed to ensure it doesn't get processed again within the current request,
+		// as it might happen with webhooks with multiple hooks defined in `LLMS_REST_Webhooks::get_hooks()`.
+		$this->processed[] = end( $args );
 
 		/**
 		 * Disable background processing of webhooks by returning a falsy

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -5,7 +5,7 @@
  * @package LifterLMS_REST/Models
  *
  * @since 1.0.0-beta.1
- * @version 1.0.0-beta.11
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -341,13 +341,14 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	}
 
 	/**
-	 * Processes information from the origination action hook
+	 * Processes information from the origination action hook.
 	 *
 	 * Determines if the webhook should be delivered and whether or not it should be scheduled or delivered immediately.
 	 *
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.17 Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request.
 	 *                      And don't rely anymore on the webhook's `pending_delivery` property to achieve the same goal.
+	 * @since [version] Updated the proccessed flag to use the second argument (Enrollment Object ID) of `$args`.
 	 *
 	 * @param mixed ...$args Arguments from the hook.
 	 * @return int|false Timestamp of the scheduled event when the webhook is successfully scheduled.
@@ -359,7 +360,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 			return false;
 		}
 
-		// Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request,
+		// Mark this hook's second argument (Enrollment Object ID) as processed to ensure it doesn't get processed again within the current request,
 		// as it might happen with webhooks with multiple hookes defined in `LLMS_REST_Webhooks::get_hooks()`.
 		$this->processed[] = $args[2];
 


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
The array index was set to `User ID` instead of the `Enrolment Post (Course / Membership) ID`.

The `$args` consist of the below array:

`
(
    [0] => 97 (User ID)
    [1] => 2243 (Enrollment Post ID)
)
`

That's why it was only processing the one request after marking it as processed as all the `$args` contain the same User ID.


Fixes https://github.com/gocodebox/lifterlms/issues/2568

## How has this been tested?
Manually.

## Types of changes
Bug fix

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

