### PR TITLE
Fix membership auto-enroll webhooks

### DIFF
--- a/.changelogs/2568-fix-membership-auto-enroll-webhooks.yml
+++ b/.changelogs/2568-fix-membership-auto-enroll-webhooks.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2568"
+entry: Update the processed flag to use all arguments.

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -192,6 +192,8 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 *
 	 * Helps avoid duplication of data being sent for topics that have more than one hook defined.
 	 *
+	 * @since [version] Verify the processed flag with all arguments of `$args`.
+	 *
 	 * @param array $args Numeric array of arguments from the originating hook.
 	 * @return bool
 	 */
@@ -348,6 +350,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.17 Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request.
 	 *                      And don't rely anymore on the webhook's `pending_delivery` property to achieve the same goal.
+	 * @since [version] Updated the processed flag to use all arguments of `$args`.
 	 *
 	 * @param mixed ...$args Arguments from the hook.
 	 * @return int|false Timestamp of the scheduled event when the webhook is successfully scheduled.

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -328,7 +328,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.17 Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request.
 	 *                      And don't rely anymore on the webhook's `pending_delivery` property to achieve the same goal.
-	 * @since [version] Updated the processed flag to use all arguments of `$args`.
+	 * @since [version] Remove the processed flag as the ActionScheduler prevents multiple additions of the same hook.
 	 *
 	 * @param mixed ...$args Arguments from the hook.
 	 * @return int|false Timestamp of the scheduled event when the webhook is successfully scheduled.
@@ -399,6 +399,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * Determines if an originating action qualifies for webhook delivery
 	 *
 	 * @since 1.0.0-beta.1
+	 * @since [verison] Removed the "is already processed" check since ActionScheduler prevents duplicates.
 	 *
 	 * @param array $args Numeric array of arguments from the originating hook.
 	 * @return bool

--- a/includes/models/class-llms-rest-webhook.php
+++ b/includes/models/class-llms-rest-webhook.php
@@ -196,7 +196,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 	 * @return bool
 	 */
 	protected function is_already_processed( $args ) {
-		return false !== array_search( $args[0], $this->processed, true );
+		return false !== array_search( $args, $this->processed, true );
 	}
 
 	/**
@@ -361,7 +361,7 @@ class LLMS_REST_Webhook extends LLMS_REST_Webhook_Data {
 
 		// Mark this hook's first argument as processed to ensure it doesn't get processed again within the current request,
 		// as it might happen with webhooks with multiple hookes defined in `LLMS_REST_Webhooks::get_hooks()`.
-		$this->processed[] = $args[0];
+		$this->processed[] = $args;
 
 		/**
 		 * Disable background processing of webhooks by returning a falsy

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -966,32 +966,4 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 
 	}
 
-	/**
-	 * Test should_deliver() method with already processed hooks().
-	 *
-	 * @since 1.0.0-beta.17
-	 *
-	 * @return void
-	 */
-	public function test_should_deliver_already_processed() {
-
-		$webhook = LLMS_REST_API()->webhooks()->create( array(
-			'delivery_url' => 'https://mock.tld',
-			'topic' => 'student.created',
-			'status' => 'active',
-		) );
-
-		$student_id = $this->factory->student->create();
-
-		// Not processed.
-		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $webhook, 'should_deliver', array( array( $student_id ) ) ) );
-
-		// Process the hook.
-		$webhook->process_hook( $student_id );
-
-		// Processed.
-		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $webhook, 'should_deliver', array( array( $student_id ) ) ) );
-
-	}
-
 }

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -761,6 +761,14 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 
 	}
 
+
+	/**
+	 * Test scheduling a webhook via multiple hooks, ensuring only one is scheduled for delivery.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function test_multiple_hooks_for_single_webhook_only_schedules_once() {
 
 		$webhook = LLMS_REST_API()->webhooks()->create( array(
@@ -780,9 +788,9 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 	}
 
 	/**
-	 * Test scheduling enrollment.created via a membership enrollment with multiple auto enroll courses
+	 * Test scheduling enrollment.created via a membership enrollment with multiple auto enroll courses.
 	 *
-	 * @since Unknown
+	 * @since [version]
 	 *
 	 * @return void
 	 */

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -762,6 +762,69 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 	}
 
 	/**
+	 * Test scheduling enrollment.created via a membership enrollment with multiple auto enroll courses
+	 *
+	 * @since Unknown
+	 *
+	 * @return void
+	 */
+	public function test_scheduling_enrollment_created_through_membership() {
+
+		$webhook = LLMS_REST_API()->webhooks()->create( array(
+			'delivery_url' => 'https://mock.tld',
+			'topic' => 'enrollment.created',
+			'status' => 'active',
+		) );
+
+		$webhook->enqueue();
+
+		$student_id =   $this->factory->student->create();
+		$membership_id = $this->factory->membership->create();
+		$course_id       = $this->factory->course->create( array( 'sections' => 0 ) );
+		$second_course_id = $this->factory->course->create( array( 'sections' => 0));
+
+		$membership = new LLMS_Membership( $membership_id );
+		$membership->add_auto_enroll_courses( array( $course_id, $second_course_id ), true );
+
+		$schedule_args_first_course = array(
+			'webhook_id' => $webhook->get( 'id' ),
+			'args'       => array( $student_id, $course_id ),
+		);
+
+		$schedule_args_second_course = array(
+			'webhook_id' => $webhook->get( 'id' ),
+			'args'       => array( $student_id, $second_course_id ),
+		);
+
+		$schedule_args_membership = array(
+			'webhook_id' => $webhook->get( 'id' ),
+			'args'       => array( $student_id, $membership_id ),
+		);
+
+		llms_enroll_student( $student_id, $membership_id );
+
+		$this->assertTrue( as_has_scheduled_action( 'lifterlms_rest_deliver_webhook_async', $schedule_args_first_course, 'llms-webhooks' ) );
+		$this->assertTrue( as_has_scheduled_action( 'lifterlms_rest_deliver_webhook_async', $schedule_args_second_course, 'llms-webhooks' ) );
+		$this->assertTrue( as_has_scheduled_action( 'lifterlms_rest_deliver_webhook_async', $schedule_args_membership, 'llms-webhooks' ) );
+		$this->assertCount(1, as_get_scheduled_actions( array(
+			'hook' => 'lifterlms_rest_deliver_webhook_async',
+			'args' => $schedule_args_first_course,
+			'per_page' => -1
+		) ) );
+		$this->assertCount(1, as_get_scheduled_actions( array(
+			'hook' => 'lifterlms_rest_deliver_webhook_async',
+			'args' => $schedule_args_second_course,
+			'per_page' => -1
+		) ) );
+		$this->assertCount(1, as_get_scheduled_actions( array(
+			'hook' => 'lifterlms_rest_deliver_webhook_async',
+			'args' => $schedule_args_membership,
+			'per_page' => -1
+		) ) );
+	}
+
+
+	/**
 	 * Test ping() on unresolveable urls.
 	 *
 	 * @since 1.0.0-beta.1

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -775,7 +775,7 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 		wp_trash_post($membership_id);
 		wp_delete_post($membership_id);
 
-		$this->assertCount(1, as_get_scheduled_actions( array( 'hook' => 'lifterlms_rest_deliver_webhook_async')));
+		$this->assertCount(1, as_get_scheduled_actions( array( 'hook' => 'lifterlms_rest_deliver_webhook_async' ) ) );
 	}
 
 	/**

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -761,6 +761,23 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 
 	}
 
+	public function test_multiple_hooks_for_single_webhook_only_schedules_once() {
+		$webhook = LLMS_REST_API()->webhooks()->create( array(
+			'delivery_url' => 'https://mock.tld',
+			'topic' => 'membership.deleted',
+			'status' => 'active',
+		) );
+
+		$webhook->enqueue();
+
+		$membership_id = $this->factory->membership->create();
+
+		wp_trash_post($membership_id);
+		wp_delete_post($membership_id);
+
+		$this->assertCount(1, as_get_scheduled_actions( array( 'hook' => 'lifterlms_rest_deliver_webhook_async')));
+	}
+
 	/**
 	 * Test scheduling enrollment.created via a membership enrollment with multiple auto enroll courses
 	 *

--- a/tests/unit-tests/class-llms-rest-test-webhook.php
+++ b/tests/unit-tests/class-llms-rest-test-webhook.php
@@ -762,6 +762,7 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 	}
 
 	public function test_multiple_hooks_for_single_webhook_only_schedules_once() {
+
 		$webhook = LLMS_REST_API()->webhooks()->create( array(
 			'delivery_url' => 'https://mock.tld',
 			'topic' => 'membership.deleted',
@@ -795,9 +796,9 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 
 		$webhook->enqueue();
 
-		$student_id =   $this->factory->student->create();
-		$membership_id = $this->factory->membership->create();
-		$course_id       = $this->factory->course->create( array( 'sections' => 0 ) );
+		$student_id       = $this->factory->student->create();
+		$membership_id    = $this->factory->membership->create();
+		$course_id        = $this->factory->course->create( array( 'sections' => 0 ) );
 		$second_course_id = $this->factory->course->create( array( 'sections' => 0));
 
 		$membership = new LLMS_Membership( $membership_id );
@@ -807,12 +808,10 @@ class LLMS_REST_Test_Webhook extends LLMS_REST_Unit_Test_Case_Base {
 			'webhook_id' => $webhook->get( 'id' ),
 			'args'       => array( $student_id, $course_id ),
 		);
-
 		$schedule_args_second_course = array(
 			'webhook_id' => $webhook->get( 'id' ),
 			'args'       => array( $student_id, $second_course_id ),
 		);
-
 		$schedule_args_membership = array(
 			'webhook_id' => $webhook->get( 'id' ),
 			'args'       => array( $student_id, $membership_id ),


### PR DESCRIPTION
## Description

Currently there is a check to avoid the same webhook firing multiple times, but it's only checking the first argument or ID. For webhooks like the one that fires for the `enrollment.created` topic, there's two arguments: the student ID and the product ID (course or membership). Because of this, for an enrollment in a membership with one or more auto enrolled courses, only the webhook for the first course fires.

This PR changes the logic to look at the entire argument array when determining if there is a duplicate webhook. However from testing, it appears that the Action Scheduler will not allow a duplicate entry to be added anyway, so the check can likely be removed entirely.

Fixes https://github.com/gocodebox/lifterlms/issues/2568

## How has this been tested?

Automated tests, and manually [with the instructions on the ticket](https://github.com/gocodebox/lifterlms/issues/2568).

## Screenshots <!-- if applicable -->

<img width="888" alt="Captura de pantalla 2023-11-15 a las 4 34 07 p  m" src="https://github.com/gocodebox/lifterlms-rest/assets/627497/86a6febe-a6f4-48f6-89d6-66de7fce94e8">
<img width="882" alt="Captura de pantalla 2023-11-15 a las 4 34 14 p  m" src="https://github.com/gocodebox/lifterlms-rest/assets/627497/ebac41fd-6e23-467d-848b-f99f781fa216">
<img width="884" alt="Captura de pantalla 2023-11-15 a las 4 34 21 p  m" src="https://github.com/gocodebox/lifterlms-rest/assets/627497/139e0f1c-bad2-4a7c-a79e-551843913f9f">
<img width="881" alt="Captura de pantalla 2023-11-15 a las 4 34 28 p  m" src="https://github.com/gocodebox/lifterlms-rest/assets/627497/cbb90b61-4586-4f8a-a35f-1683970009f1">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Bug fix
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

