### PR TITLE
Misc fixes instructor & student list query and quiz link

### DIFF
--- a/.changelogs/misc-fixes-instructor-student-list-query-and-quiz-link-1.yml
+++ b/.changelogs/misc-fixes-instructor-student-list-query-and-quiz-link-1.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Removes the unavailable quiz resource link from the lessons resource
+  until the quiz resource is added.

--- a/.changelogs/misc-fixes-instructor-student-list-query-and-quiz-link.yml
+++ b/.changelogs/misc-fixes-instructor-student-list-query-and-quiz-link.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Show only instructor and student roles in the instructor and student list
+  responses by default.

--- a/includes/server/class-llms-rest-instructors-controller.php
+++ b/includes/server/class-llms-rest-instructors-controller.php
@@ -48,8 +48,38 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return current_user_can( 'list_users', $item_id );
-
 	}
+
+
+	/**
+	 * Format query arguments to retrieve a collection of objects
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array|WP_Error
+	 */
+	protected function prepare_collection_query_args( $request ) {
+
+		$query_args = parent::prepare_collection_query_args( $request );
+		if ( is_wp_error( $query_args ) ) {
+			return $query_args;
+		}
+
+		if ( empty( $request['roles'] ) ) {
+			$query_args = array_merge(
+				$query_args,
+				array(
+					'roles' => array(
+						'instructor',
+					),
+				)
+			);
+		}
+
+		return $query_args;
+	}
+
 
 	/**
 	 * Determine if current user has permission to create a user.
@@ -66,7 +96,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return $this->check_roles_permissions( $request );
-
 	}
 
 	/**
@@ -84,7 +113,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -115,7 +143,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		);
 
 		return $params;
-
 	}
 
 	/**
@@ -133,7 +160,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -150,7 +176,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		$schema['properties']['roles']['default'] = array( 'instructor' );
 
 		return $schema;
-
 	}
 
 	/**
@@ -169,7 +194,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -184,7 +208,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 
 		$instructor = llms_get_instructor( $id );
 		return $instructor ? $instructor : llms_rest_not_found_error();
-
 	}
 
 	/**
@@ -206,7 +229,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		);
 
 		return $links;
-
 	}
 
 	/**
@@ -234,7 +256,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return $object;
-
 	}
 
 	/**
@@ -257,7 +278,5 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return $this->check_roles_permissions( $request );
-
 	}
-
 }

--- a/includes/server/class-llms-rest-instructors-controller.php
+++ b/includes/server/class-llms-rest-instructors-controller.php
@@ -50,7 +50,6 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 		return current_user_can( 'list_users', $item_id );
 	}
 
-
 	/**
 	 * Format query arguments to retrieve a collection of objects
 	 *
@@ -70,16 +69,13 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 			$query_args = array_merge(
 				$query_args,
 				array(
-					'roles' => array(
-						'instructor',
-					),
+					'roles' => $this->get_item_schema_base()['properties']['roles']['default'],
 				)
 			);
 		}
 
 		return $query_args;
 	}
-
 
 	/**
 	 * Determine if current user has permission to create a user.

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -91,7 +91,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		parent::__construct();
 
 		$this->collection_params = $this->build_collection_params();
-
 	}
 
 	/**
@@ -254,7 +253,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		 * @param array           $schema        The item schema.
 		 */
 		return apply_filters( 'llms_rest_pre_insert_lesson', $prepared_item, $request, $schema );
-
 	}
 
 	/**
@@ -307,7 +305,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		return ! empty( $to_set );
-
 	}
 
 	/**
@@ -469,7 +466,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		$schema['properties'] = array_merge( (array) $schema['properties'], $lesson_properties );
 
 		return $schema;
-
 	}
 
 	/**
@@ -513,7 +509,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		);
 
 		return $query_params;
-
 	}
 
 	/**
@@ -597,7 +592,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		 * @param WP_REST_Request $request Full details about the request.
 		 */
 		return apply_filters( 'llms_rest_prepare_lesson_object_response', $data, $lesson, $request );
-
 	}
 
 	/**
@@ -694,7 +688,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		 * @param LLMS_Lesson $lesson  Lesson object.
 		 */
 		return apply_filters( 'llms_rest_lesson_filters_removed_for_response', $filters, $lesson );
-
 	}
 
 	/**
@@ -774,14 +767,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 			);
 		}
 
-		// Quiz.
-		if ( $lesson->is_quiz_enabled() ) {
-			$quiz                 = $lesson->get_quiz();
-			$lesson_links['quiz'] = array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', 'llms/v1', 'quizzes', $quiz->get( 'id' ) ) ),
-			);
-		}
-
 		$links = array_merge( $links, $lesson_links );
 
 		/**
@@ -793,7 +778,6 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		 * @param LLMS_Lesson $lesson Lesson object.
 		 */
 		return apply_filters( 'llms_rest_lesson_links', $links, $lesson );
-
 	}
 
 	/**
@@ -821,7 +805,5 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		 * At the moment we grant lessons read permission only to who can edit lessons.
 		 */
 		return parent::check_update_permission( $lesson );
-
 	}
-
 }

--- a/includes/server/class-llms-rest-students-controller.php
+++ b/includes/server/class-llms-rest-students-controller.php
@@ -58,7 +58,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return current_user_can( 'view_students', $item_id );
-
 	}
 
 	/**
@@ -76,7 +75,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return $this->check_roles_permissions( $request );
-
 	}
 
 	/**
@@ -94,7 +92,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -125,7 +122,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		);
 
 		return $params;
-
 	}
 
 	/**
@@ -141,7 +137,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		$schema['properties']['roles']['default'] = array( 'student' );
 
 		return $schema;
-
 	}
 
 	/**
@@ -159,7 +154,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -181,7 +175,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -197,7 +190,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 
 		$student = llms_get_student( $id, false );
 		return $student ? $student : llms_rest_not_found_error();
-
 	}
 
 	/**
@@ -230,7 +222,34 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return $query;
+	}
 
+	/**
+	 * Format query arguments to retrieve a collection of objects
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array|WP_Error
+	 */
+	protected function prepare_collection_query_args( $request ) {
+
+		$query_args = parent::prepare_collection_query_args( $request );
+		if ( is_wp_error( $query_args ) ) {
+			return $query_args;
+		}
+
+		if ( empty( $request['roles'] ) ) {
+			$query_args = array_merge(
+				$query_args,
+				array(
+					'roles' =>
+						$this->get_item_schema_base()['properties']['roles']['default'],
+				)
+			);
+		}
+
+		return $query_args;
 	}
 
 	/**
@@ -264,7 +283,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 				$query->query_where  .= " AND (  p_{$post_id}_stat IS NULL OR  p_{$post_id}_stat != 'enrolled' )";
 			}
 		}
-
 	}
 
 	/**
@@ -288,7 +306,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 			ORDER BY updated_date DESC
 			LIMIT 1
 		) AS p_{$post_id}_stat";
-
 	}
 
 	/**
@@ -356,7 +373,6 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		);
 
 		return $links;
-
 	}
 
 	/**
@@ -378,7 +394,5 @@ class LLMS_REST_Students_Controller extends LLMS_REST_Users_Controller {
 		}
 
 		return $this->check_roles_permissions( $request );
-
 	}
-
 }

--- a/tests/unit-tests/server/class-llms-rest-test-instructors-controllers.php
+++ b/tests/unit-tests/server/class-llms-rest-test-instructors-controllers.php
@@ -166,10 +166,10 @@ class LLMS_REST_Test_Instructors_Controllers extends LLMS_REST_Unit_Test_Case_Us
 		global $wpdb;
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->users}" );
 
-		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$admin_id = $this->factory->user->create( array( 'role' => 'instructor' ) );
 
 		wp_set_current_user( $admin_id );
-		// other 24 users except the admin who's an instructor too.
+
 		$ids = $this->factory->user->create_many( 24, array( 'role' => 'instructor' ) );
 		$this->pagination_test( $this->route, $admin_id );
 

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -687,10 +687,6 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 					$expected_link_rels = $this->expected_link_rels;
 			endswitch;
 
-			if ( $lesson->is_quiz_enabled() ) {
-				$expected_link_rels[] = 'quiz';
-			}
-
 			$this->assertEquals( $expected_link_rels, array_keys( $response->get_links() ) );
 
 		}

--- a/tests/unit-tests/server/class-llms-rest-test-students-controllers.php
+++ b/tests/unit-tests/server/class-llms-rest-test-students-controllers.php
@@ -624,8 +624,8 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 	public function test_get_items_orderby_email() {
 
 		wp_set_current_user( $this->user_admin );
-		$low = $this->factory->user->create( array( array( 'user_email' => 'aemail@mock.tld', 'role' => 'student' ) ) );
-		$high = $this->factory->user->create( array( array( 'user_email' => 'bemail@mock.tld', 'role' => 'student' ) ) );
+		$low = $this->factory->user->create( array( array( 'user_email' => 'aemail@mock.tld' ), 'role' => 'student' ) );
+		$high = $this->factory->user->create( array( array( 'user_email' => 'bemail@mock.tld' ), 'role' => 'student' ) );
 		$args = array( 'include' => array( $low, $high ), 'orderby' => 'email' );
 
 		// Default / asc.

--- a/tests/unit-tests/server/class-llms-rest-test-students-controllers.php
+++ b/tests/unit-tests/server/class-llms-rest-test-students-controllers.php
@@ -543,12 +543,12 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 
 		global $wpdb;
 
+		$student_total = 25;
 		$this->factory->user->create_many( 5 );
-		$this->factory->student->create_many( 25 );
-		$db_total = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" ) );
+		$this->factory->student->create_many( $student_total );
 
 
-		$db_pages = ceil( $db_total / 10 );
+		$db_pages = ceil( $student_total / 10 );
 
 		wp_set_current_user( $this->user_admin );
 
@@ -561,7 +561,7 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 
 		// Check Pagination headers.
 		$headers = $res->get_headers();
-		$this->assertEquals( $db_total, $headers['X-WP-Total'] );
+		$this->assertEquals( $student_total, $headers['X-WP-Total'] );
 		$this->assertEquals( $db_pages, $headers['X-WP-TotalPages'] );
 
 		// Link headers.
@@ -590,7 +590,7 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 
 		// Check Pagination headers.
 		$headers = $res->get_headers();
-		$this->assertEquals( $db_total, $headers['X-WP-Total'] );
+		$this->assertEquals( $student_total, $headers['X-WP-Total'] );
 		$this->assertEquals( 1, $headers['X-WP-TotalPages'] );
 
 		// No links because this is the only page.
@@ -606,8 +606,8 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 	public function test_get_items_orderby_id() {
 
 		wp_set_current_user( $this->user_admin );
-		$low = $this->factory->user->create( array() );
-		$high = $this->factory->user->create( array() );
+		$low = $this->factory->user->create( array( 'role' => 'student', ) );
+		$high = $this->factory->user->create( array( 'role' => 'student', ) );
 		$args = array( 'include' => array( $low, $high ), 'orderby' => 'id' );
 
 		// Default / asc.
@@ -624,8 +624,8 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 	public function test_get_items_orderby_email() {
 
 		wp_set_current_user( $this->user_admin );
-		$low = $this->factory->user->create( array( array( 'user_email' => 'aemail@mock.tld' ) ) );
-		$high = $this->factory->user->create( array( array( 'user_email' => 'bemail@mock.tld' ) ) );
+		$low = $this->factory->user->create( array( array( 'user_email' => 'aemail@mock.tld', 'role' => 'student' ) ) );
+		$high = $this->factory->user->create( array( array( 'user_email' => 'bemail@mock.tld', 'role' => 'student' ) ) );
 		$args = array( 'include' => array( $low, $high ), 'orderby' => 'email' );
 
 		// Default / asc.
@@ -642,8 +642,8 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 	public function test_get_items_orderby_name() {
 
 		wp_set_current_user( $this->user_admin );
-		$low = $this->factory->user->create( array( 'display_name' => 'A Name' ) );
-		$high = $this->factory->user->create( array( 'display_name' => 'B Name' ) );
+		$low = $this->factory->user->create( array( 'display_name' => 'A Name', 'role' => 'student' ) );
+		$high = $this->factory->user->create( array( 'display_name' => 'B Name', 'role' => 'student' ) );
 		$args = array( 'include' => array( $low, $high ), 'orderby' => 'name' );
 
 		// Default / asc.
@@ -660,8 +660,8 @@ class LLMS_REST_Test_Students_Controllers extends LLMS_REST_Unit_Test_Case_Users
 	public function test_get_items_orderby_registered_date() {
 
 		wp_set_current_user( $this->user_admin );
-		$low = $this->factory->user->create( array( 'user_registered' => date( 'Y-m-d h:i:s', strtotime( '-5 days', time() ) ) ) );
-		$high = $this->factory->user->create();
+		$low = $this->factory->user->create( array( 'role' => 'student', 'user_registered' => date( 'Y-m-d h:i:s', strtotime( '-5 days', time() ) ) ) );
+		$high = $this->factory->user->create( array( 'role' => 'student' ) );
 		$args = array( 'include' => array( $low, $high ), 'orderby' => 'registered_date' );
 
 		// Default / asc.


### PR DESCRIPTION

## Description

Removes the "quiz" link from lessons since the quiz resource doesn't exist.

Sets the default listing of the students and instructors endpoints to be role "student" and "instructor" by default. It can still be changed using the `roles` query param.

Refs #48 
Fixes #330

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

<img width="1671" alt="Captura de pantalla 2024-07-17 a las 12 16 02 p  m" src="https://github.com/user-attachments/assets/8cd5e678-9b21-45e0-864c-1dc1261b9a71">
<img width="1671" alt="Captura de pantalla 2024-07-17 a las 12 16 17 p  m" src="https://github.com/user-attachments/assets/ef3ea30a-d2d6-4675-bfbf-fcfc5d102701">

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

