### PR TITLE
Handle removing of SQL_CALC_FOUND_ROWS in core.

### DIFF
--- a/.changelogs/fix_remove-sql-calc-found-rows.yml
+++ b/.changelogs/fix_remove-sql-calc-found-rows.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Handle removal of depreciated SQL_CALC_FOUND_ROWS for counting query results.

--- a/includes/class-llms-rest-api-keys-query.php
+++ b/includes/class-llms-rest-api-keys-query.php
@@ -125,6 +125,7 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.16 Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 * @since 1.0.0-beta.22 Renamed from `preprare_query()`.
+	 * @since [version] Set `$this->count_query` for found results without `SQL_CALC_FOUND_ROWS`.
 	 *
 	 * @return string
 	 */
@@ -132,9 +133,16 @@ class LLMS_REST_API_Keys_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
+		$from  = "FROM {$wpdb->prefix}lifterlms_api_keys";
+		$where = $this->sql_where();
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$this->count_query = "SELECT COUNT(*) {$from} {$where}";
+		}
+
 		return "SELECT {$this->sql_select_columns( 'id' )}
-				FROM {$wpdb->prefix}lifterlms_api_keys
-				{$this->sql_where()}
+				{$from}
+				{$where}
 				{$this->sql_orderby()}
 				{$this->sql_limit()};";
 

--- a/includes/class-llms-rest-webhooks-query.php
+++ b/includes/class-llms-rest-webhooks-query.php
@@ -123,6 +123,7 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 	 * @since 1.0.0-beta.1
 	 * @since 1.0.0-beta.16 Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 * @since 1.0.0-beta.22 Renamed from `preprare_query()`.
+	 * @since [version] Set `$this->count_query` for found results without `SQL_CALC_FOUND_ROWS`.
 	 *
 	 * @return string
 	 */
@@ -130,9 +131,16 @@ class LLMS_REST_Webhooks_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
+		$from  = "FROM {$wpdb->prefix}lifterlms_webhooks";
+		$where = $this->sql_where();
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$this->count_query = "SELECT COUNT(*) {$from} {$where}";
+		}
+
 		return "SELECT {$this->sql_select_columns( 'id' )}
-				FROM {$wpdb->prefix}lifterlms_webhooks
-				{$this->sql_where()}
+				{$from}
+				{$where}
 				{$this->sql_orderby()}
 				{$this->sql_limit()};";
 

--- a/includes/server/class-llms-rest-enrollments-controller.php
+++ b/includes/server/class-llms-rest-enrollments-controller.php
@@ -889,6 +889,7 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 	 * @since 1.0.0-beta.4 Enrollment's post_id and student_id casted to integer.
 	 * @since 1.0.0-beta.10 Added subquery to retrieve the enrollments trigger.
 	 * @since 1.0.0-beta.18 Fixed wrong trigger retrieved when multiple trigger were present for the same user,post pair.
+	 * @since [version] Replaced `SQL_CALC_FOUND_ROWS` / `FOUND_ROWS()` with a separate `COUNT(DISTINCT)` query.
 	 *
 	 * @param  array           $query_args Array of collection arguments.
 	 * @param  WP_REST_Request $request    Optional. Full details about the request. Default null.
@@ -989,19 +990,18 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 
 		$query = new stdClass();
 
-		$select_found_rows = empty( $query_args['no_found_rows'] ) ? esc_sql( 'SQL_CALC_FOUND_ROWS' ) : '';
-
-		// the query.
-		$query->items = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-				SELECT {$select_found_rows} DISTINCT upm.post_id AS post_id, upm.user_id as student_id, upm.updated_date as date_created, upm2.updated_date as date_updated, upm2.meta_value as status, upm3.meta_value as etrigger
-				FROM {$wpdb->prefix}lifterlms_user_postmeta AS upm
+		$from_joins_where = "FROM {$wpdb->prefix}lifterlms_user_postmeta AS upm
 				JOIN {$updated_date_status} as upm2 ON upm.post_id = upm2.post_id AND upm.user_id = upm2.user_id
 				JOIN {$trigger} as upm3 ON upm.post_id = upm3.post_id AND upm.user_id = upm3.user_id
 				WHERE upm.meta_key = '_start_date'
 				AND upm.{$id_column} = %d
-				{$filter}
+				{$filter}";
+
+		$query->items = $wpdb->get_results(
+			$wpdb->prepare(
+				"
+				SELECT DISTINCT upm.post_id AS post_id, upm.user_id as student_id, upm.updated_date as date_created, upm2.updated_date as date_updated, upm2.meta_value as status, upm3.meta_value as etrigger
+				{$from_joins_where}
 				{$order}
 				{$limit};
 				",
@@ -1023,7 +1023,18 @@ class LLMS_REST_Enrollments_Controller extends LLMS_REST_Controller {
 			}
 		}
 
-		$query->found_results = empty( $query_args['no_found_rows'] ) ? absint( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) ) : $count; // no-cache ok.
+		if ( empty( $query_args['no_found_rows'] ) ) {
+			$query->found_results = absint(
+				$wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+					$wpdb->prepare(
+						"SELECT COUNT(DISTINCT upm.post_id, upm.user_id) {$from_joins_where}",
+						array( $query_args['id'] )
+					)
+				)
+			);
+		} else {
+			$query->found_results = $count;
+		}
 
 		return $query;
 


### PR DESCRIPTION

## Description
If SQL_CALC_FOUND_ROWS is removed in core, need to account for that in our queries.

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

