### PR TITLE
Additional checks on permissions

### DIFF
--- a/.changelogs/fix_rest-api-checks.yml
+++ b/.changelogs/fix_rest-api-checks.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: Additional checks on item permissions.

--- a/includes/server/class-llms-rest-access-plans-controller.php
+++ b/includes/server/class-llms-rest-access-plans-controller.php
@@ -411,6 +411,10 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 
 		// Post id.
 		if ( ! empty( $schema['properties']['post_id'] ) && isset( $request['post_id'] ) ) {
+			if ( ! current_user_can( 'edit_post', absint( $request['post_id'] ) ) ) {
+				return llms_rest_authorization_required_error( __( 'Sorry, you are not allowed to manage access plans for the requested product.', 'lifterlms' ) );
+			}
+
 			$prepared_item['product_id'] = $request['post_id'];
 		}
 

--- a/includes/server/class-llms-rest-access-plans-controller.php
+++ b/includes/server/class-llms-rest-access-plans-controller.php
@@ -69,7 +69,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 		);
 
 		return $schema;
-
 	}
 
 	/**
@@ -164,7 +163,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 		$can_update = $this->related_product_permissions_check( $can_update, $request );
 
 		return is_wp_error( $can_update ) ? $can_update : $this->allow_request_when_access_plan_limit_not_reached( $request );
-
 	}
 
 	/**
@@ -181,7 +179,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 
 		// If current user cannot delete the item because of authorization, check if the current user can edit the "parent" course/membership.
 		return $this->related_product_permissions_check( $can_delete, $request );
-
 	}
 
 	/**
@@ -232,7 +229,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 		 * @param LLMS_Access_Plan $access_plan LLMS Access Plan instance.
 		 */
 		return apply_filters( 'llms_rest_access_plan_links', $links, $access_plan );
-
 	}
 
 	/**
@@ -617,7 +613,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 		$this->add_subordinate_props( $to_set, $saved_props, $creating );
 
 		$this->unset_subordinate_props( $to_set, $saved_props );
-
 	}
 
 	/**
@@ -661,7 +656,6 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		$to_set = array_merge( $to_set, $subordinate_props );
-
 	}
 
 	/**
@@ -783,5 +777,4 @@ class LLMS_REST_Access_Plans_Controller extends LLMS_REST_Posts_Controller {
 
 		return true;
 	}
-
 }

--- a/includes/server/class-llms-rest-api-keys-controller.php
+++ b/includes/server/class-llms-rest-api-keys-controller.php
@@ -211,7 +211,10 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	public function create_item( $request ) {
 
 		$prepared = $this->prepare_item_for_database( $request );
-		$key      = LLMS_REST_API()->keys()->create( $prepared );
+		if ( is_wp_error( $prepared ) ) {
+			return $prepared;
+		}
+		$key = LLMS_REST_API()->keys()->create( $prepared );
 		if ( is_wp_error( $request ) ) {
 			$request->add_data( array( 'status' => 400 ) );
 			return $request;
@@ -345,7 +348,10 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 	public function update_item( $request ) {
 
 		$prepared = $this->prepare_item_for_database( $request );
-		$key      = LLMS_REST_API()->keys()->update( $prepared );
+		if ( is_wp_error( $prepared ) ) {
+			return $prepared;
+		}
+		$key = LLMS_REST_API()->keys()->update( $prepared );
 		if ( is_wp_error( $request ) ) {
 			$request->add_data( array( 'status' => 400 ) );
 			return $request;
@@ -427,7 +433,11 @@ class LLMS_REST_API_Keys_Controller extends LLMS_REST_Controller {
 		}
 
 		if ( ! empty( $schema['properties']['user_id'] ) && isset( $request['user_id'] ) ) {
-			$prepared['user_id'] = (int) $request['user_id'];
+			$user_id = (int) $request['user_id'];
+			if ( ! current_user_can( 'edit_user', $user_id ) ) {
+				return llms_rest_authorization_required_error( __( 'You are not allowed to create or edit an API key for this user.', 'lifterlms' ) );
+			}
+			$prepared['user_id'] = $user_id;
 		}
 
 		if ( ! empty( $schema['properties']['permissions'] ) && isset( $request['permissions'] ) ) {

--- a/includes/server/class-llms-rest-instructors-controller.php
+++ b/includes/server/class-llms-rest-instructors-controller.php
@@ -47,7 +47,48 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 			return true;
 		}
 
-		return current_user_can( 'list_users', $item_id );
+		if ( ! current_user_can( 'list_users', $item_id ) ) {
+			return false;
+		}
+
+		return $this->is_instructor( $item_id );
+	}
+
+	/**
+	 * Retrieve the list of roles considered instructors for this endpoint.
+	 *
+	 * @since [version]
+	 *
+	 * @return string[]
+	 */
+	protected function get_instructor_roles() {
+
+		/**
+		 * Filters the list of user roles served by the instructors REST endpoint.
+		 *
+		 * @since [version]
+		 *
+		 * @param string[] $roles List of role keys treated as instructors.
+		 */
+		return apply_filters(
+			'llms_rest_instructor_roles',
+			array( 'instructor', 'instructors_assistant' )
+		);
+	}
+
+	/**
+	 * Determine if a given user has an instructor role.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $user_id WP_User id.
+	 * @return bool
+	 */
+	protected function is_instructor( $user_id ) {
+
+		$user = get_userdata( $user_id );
+
+		return $user ? (bool) array_intersect( $this->get_instructor_roles(), (array) $user->roles ) : false;
 	}
 
 	/**
@@ -65,14 +106,20 @@ class LLMS_REST_Instructors_Controller extends LLMS_REST_Users_Controller {
 			return $query_args;
 		}
 
+		$instructor_roles = $this->get_instructor_roles();
+		$default          = $this->get_item_schema_base()['properties']['roles']['default'];
+
 		if ( empty( $request['roles'] ) ) {
-			$query_args = array_merge(
-				$query_args,
-				array(
-					'roles' => $this->get_item_schema_base()['properties']['roles']['default'],
-				)
-			);
+			$roles = $default;
+		} else {
+			$roles = array_values( array_intersect( (array) $request['roles'], $instructor_roles ) );
+			// Requested only non-instructor roles: return instructors only, never the requested role.
+			if ( empty( $roles ) ) {
+				$roles = $default;
+			}
 		}
+
+		$query_args['roles'] = $roles;
 
 		return $query_args;
 	}

--- a/includes/server/class-llms-rest-lessons-controller.php
+++ b/includes/server/class-llms-rest-lessons-controller.php
@@ -145,18 +145,29 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		// Parent (section) id.
 		if ( ! empty( $schema['properties']['parent_id'] ) && isset( $request['parent_id'] ) ) {
 
+			$parent_section_id = absint( $request['parent_id'] );
+
 			// Retrieve the parent section.
-			$parent_section = llms_get_post( $request['parent_id'] );
+			$parent_section = $parent_section_id ? llms_get_post( $parent_section_id ) : null;
 
-			$prepared_item['parent_section'] = $parent_section && is_a( $parent_section, 'LLMS_Section' ) ? $request['parent_id'] : 0;
+			if ( $parent_section && is_a( $parent_section, 'LLMS_Section' ) ) {
 
-			// Retrieve the parent course id.
-			if ( $prepared_item['parent_section'] ) {
 				$parent_course = $parent_section->get_course();
+
+				if ( ! current_user_can( 'edit_post', $parent_section_id ) ||
+					! $parent_course || ! is_a( $parent_course, 'LLMS_Course' ) ||
+					! current_user_can( 'edit_post', $parent_course->get( 'id' ) ) ) {
+					return llms_rest_authorization_required_error( __( 'Sorry, you are not allowed to create or move lessons into the requested section.', 'lifterlms' ) );
+				}
+
+				$prepared_item['parent_section'] = $parent_section_id;
+				$prepared_item['parent_course']  = $parent_course->get( 'id' );
+
+			} else {
+				// An empty or invalid parent_id denotes an "orphaned" lesson.
+				$prepared_item['parent_section'] = 0;
+				$prepared_item['parent_course']  = 0;
 			}
-
-			$prepared_item['parent_course'] = ! empty( $parent_course ) && is_a( $parent_course, 'LLMS_Course' ) ? $parent_course->get( 'id' ) : 0;
-
 		}
 
 		// Course id.
@@ -166,6 +177,10 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 
 			if ( ! $parent_course || ! is_a( $parent_course, 'LLMS_Course' ) ) {
 				return llms_rest_bad_request_error( __( 'Invalid course_id param. It must be a valid Course ID.', 'lifterlms' ) );
+			}
+
+			if ( ! current_user_can( 'edit_post', $parent_course->get( 'id' ) ) ) {
+				return llms_rest_authorization_required_error( __( 'Sorry, you are not allowed to create or move lessons into the requested course.', 'lifterlms' ) );
 			}
 
 			$prepared_item['parent_course'] = $request['course_id'];
@@ -228,13 +243,20 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		// Quiz id.
-		if ( ! empty( $schema['properties']['quiz']['properties']['id'] ) && isset( $request['quiz']['id'] ) ) {
+		if ( ! empty( $schema['properties']['quiz']['properties']['id'] ) && ! empty( $request['quiz']['id'] ) ) {
+
+			$quiz_id = absint( $request['quiz']['id'] );
 
 			// check if quiz exists.
-			$quiz = llms_get_post( $request['quiz']['id'] );
+			$quiz = llms_get_post( $quiz_id );
 
 			if ( is_a( $quiz, 'LLMS_Quiz' ) ) {
-				$prepared_item['quiz'] = $request['quiz']['id'];
+
+				if ( ! current_user_can( 'edit_post', $quiz_id ) ) {
+					return llms_rest_authorization_required_error( __( 'Sorry, you are not allowed to attach the requested quiz to this lesson.', 'lifterlms' ) );
+				}
+
+				$prepared_item['quiz'] = $quiz_id;
 			}
 		}
 

--- a/includes/server/class-llms-rest-sections-controller.php
+++ b/includes/server/class-llms-rest-sections-controller.php
@@ -210,6 +210,10 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 				return llms_rest_bad_request_error( __( 'Invalid parent_id param. It must be a valid Course ID.', 'lifterlms' ) );
 			}
 
+			if ( ! current_user_can( 'edit_post', $parent_course->get( 'id' ) ) ) {
+				return llms_rest_authorization_required_error( __( 'Sorry, you are not allowed to create or move sections into the requested course.', 'lifterlms' ) );
+			}
+
 			$prepared_item['parent_course'] = $request['parent_id'];
 		}
 

--- a/includes/server/class-llms-rest-sections-controller.php
+++ b/includes/server/class-llms-rest-sections-controller.php
@@ -92,7 +92,6 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 			$this->content_controller = new $this->content_controller_class();
 			$this->content_controller->set_collection_params( $this->get_content_collection_params() );
 		}
-
 	}
 
 	/**
@@ -229,7 +228,6 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		return $prepared_item;
-
 	}
 
 	/**
@@ -289,7 +287,6 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		return $schema;
-
 	}
 
 	/**
@@ -356,7 +353,6 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		$data['order'] = $section->get( 'order' );
 
 		return $data;
-
 	}
 
 	/**
@@ -494,7 +490,6 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		return parent::check_read_permission( $section );
-
 	}
 
 	/**
@@ -529,7 +524,6 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		unset( $query_params['parent'] );
 
 		return $query_params;
-
 	}
 
 	/**
@@ -551,7 +545,5 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 		}
 
 		return $result;
-
 	}
-
 }

--- a/tests/unit-tests/server/class-llms-rest-test-access-plans.php
+++ b/tests/unit-tests/server/class-llms-rest-test-access-plans.php
@@ -581,6 +581,54 @@ class LLMS_REST_Test_Access_Plans extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test that an access plan cannot be moved onto a product the current user cannot edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_cannot_move_plan_to_unauthorized_product() {
+
+		// Instructor owns course A.
+		$instructor = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		wp_set_current_user( $instructor );
+		$course_a = $this->factory->course->create_and_get();
+
+		// Create an access plan on course A (allowed: the instructor can edit their own course).
+		$create = $this->perform_mock_request(
+			'POST',
+			$this->route,
+			array_merge(
+				$this->sample_access_plan_args,
+				array( 'post_id' => $course_a->get( 'id' ) )
+			)
+		);
+		$this->assertEquals( 201, $create->get_status() );
+		$plan_id = $create->get_data()['id'];
+
+		// Admin owns victim course B.
+		wp_set_current_user( $this->user_allowed );
+		$course_b = $this->factory->course->create();
+
+		// Back to the instructor: attempt to move the plan onto the victim course B.
+		wp_set_current_user( $instructor );
+		$update = $this->perform_mock_request(
+			'POST',
+			$this->route . '/' . $plan_id,
+			array_merge(
+				$this->sample_access_plan_args,
+				array( 'post_id' => $course_b )
+			)
+		);
+
+		$this->assertEquals( 403, $update->get_status() );
+
+		// The plan must still belong to course A.
+		$plan = new LLMS_Access_Plan( $plan_id );
+		$this->assertEquals( $course_a->get( 'id' ), $plan->get( 'product_id' ) );
+	}
+
+	/**
 	 * Test update free access plan.
 	 *
 	 * @since 1.0.0-beta-24

--- a/tests/unit-tests/server/class-llms-rest-test-api-keys-controller.php
+++ b/tests/unit-tests/server/class-llms-rest-test-api-keys-controller.php
@@ -164,6 +164,114 @@ class LLMS_REST_Test_API_Keys_Controller extends LLMS_REST_Unit_Test_Case_Server
 	}
 
 	/**
+	 * Test an LMS Manager cannot create a key owned by an Administrator.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_item_forbidden_owner() {
+
+		$manager = $this->factory->user->create( array( 'role' => 'lms_manager' ) );
+		$admin   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $manager );
+
+		$args = array(
+			'description' => 'admin key',
+			'user_id'     => $admin,
+			'permissions' => 'read_write',
+		);
+
+		$response = $this->perform_mock_request( 'POST', $this->route, $args );
+		$this->assertResponseStatusEquals( 403, $response );
+		$this->assertResponseCodeEquals( 'llms_rest_forbidden_request', $response );
+
+	}
+
+	/**
+	 * Test an LMS Manager can create a key owned by themselves.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_item_self_owner_allowed() {
+
+		$manager = $this->factory->user->create( array( 'role' => 'lms_manager' ) );
+
+		wp_set_current_user( $manager );
+
+		$args = array(
+			'description' => 'self key',
+			'user_id'     => $manager,
+			'permissions' => 'read_write',
+		);
+
+		$response = $this->perform_mock_request( 'POST', $this->route, $args );
+		$this->assertResponseStatusEquals( 201, $response );
+		$this->assertEquals( $manager, $response->get_data()['user_id'] );
+
+	}
+
+	/**
+	 * Test an LMS Manager can create a key owned by a user they're allowed to manage.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_item_manageable_owner_allowed() {
+
+		$manager = $this->factory->user->create( array( 'role' => 'lms_manager' ) );
+		$student = $this->factory->user->create( array( 'role' => 'student' ) );
+
+		wp_set_current_user( $manager );
+
+		$args = array(
+			'description' => 'student key',
+			'user_id'     => $student,
+			'permissions' => 'read_write',
+		);
+
+		$response = $this->perform_mock_request( 'POST', $this->route, $args );
+		$this->assertResponseStatusEquals( 201, $response );
+		$this->assertEquals( $student, $response->get_data()['user_id'] );
+
+	}
+
+	/**
+	 * Test an LMS Manager cannot change an existing key's owner to an Administrator.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_item_forbidden_owner_change() {
+
+		$manager = $this->factory->user->create( array( 'role' => 'lms_manager' ) );
+		$admin   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $manager );
+
+		$key = $this->get_mock_api_key( 'read_write', $manager, false );
+		$id  = $key->get( 'id' );
+
+		$response = $this->perform_mock_request(
+			'POST',
+			sprintf( '%1$s/%2$d', $this->route, $id ),
+			array( 'user_id' => $admin )
+		);
+
+		$this->assertResponseStatusEquals( 403, $response );
+		$this->assertResponseCodeEquals( 'llms_rest_forbidden_request', $response );
+
+		// Owner unchanged.
+		$this->assertEquals( $manager, LLMS_REST_API()->keys()->get( $id )->get( 'user_id' ) );
+
+	}
+
+	/**
 	 * Test the permissions check methods.
 	 *
 	 * @return void

--- a/tests/unit-tests/server/class-llms-rest-test-courses.php
+++ b/tests/unit-tests/server/class-llms-rest-test-courses.php
@@ -59,7 +59,7 @@ class LLMS_REST_Test_Courses extends LLMS_REST_Unit_Test_Case_Posts {
 				'raw'      => 'Getting Started with LifterLMS',
 			),
 			'content'      => array(
-				'rendered' => "\\n<h2 class=\"wp-block-heading\">Lorem ipsum dolor sit amet.</h2>\\n\\n\\n\\n<p>Expectoque quid ad id, quod quaerebam, respondeas. Nec enim, omnes avaritias si aeque avaritias esse dixerimus, sequetur ut etiam aequas esse dicamus.</p>\\n",
+				'rendered' => "\\n<h2 class=\"wp-block-heading\">Lorem ipsum dolor sit amet.</h2>\\n\\n\\n\\n<p class=\"wp-block-paragraph\">Expectoque quid ad id, quod quaerebam, respondeas. Nec enim, omnes avaritias si aeque avaritias esse dixerimus, sequetur ut etiam aequas esse dicamus.</p>\\n",
 				'raw'      => "<!-- wp:heading -->\\n<h2 class=\"wp-block-heading\">Lorem ipsum dolor sit amet.</h2>\\n<!-- /wp:heading -->\\n\\n<!-- wp:paragraph -->\\n<p>Expectoque quid ad id, quod quaerebam, respondeas. Nec enim, omnes avaritias si aeque avaritias esse dixerimus, sequetur ut etiam aequas esse dicamus.</p>\\n<!-- /wp:paragraph -->",
 			),
 			'date_created' => '2019-05-20 17:22:05',

--- a/tests/unit-tests/server/class-llms-rest-test-instructors-controllers.php
+++ b/tests/unit-tests/server/class-llms-rest-test-instructors-controllers.php
@@ -263,6 +263,76 @@ class LLMS_REST_Test_Instructors_Controllers extends LLMS_REST_Unit_Test_Case_Us
 	// public function test_get_item_not_found() {}
 	// public function test_get_item_success() {}
 
+	/**
+	 * An instructor must not be able to read a non-instructor (administrator) user.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_item_blocks_non_instructor_target() {
+
+		wp_set_current_user( $this->user_instructor );
+
+		// Administrator target.
+		$res = $this->perform_mock_request( 'GET', $this->route . '/' . $this->user_admin, array(), array( 'context' => 'edit' ) );
+		$this->assertNotEquals( 200, $res->get_status() );
+		$data = $res->get_data();
+		$this->assertArrayNotHasKey( 'email', (array) $data );
+		$this->assertArrayNotHasKey( 'billing_address_1', (array) $data );
+
+		// Subscriber target.
+		$res = $this->perform_mock_request( 'GET', $this->route . '/' . $this->user_subscriber, array(), array( 'context' => 'edit' ) );
+		$this->assertNotEquals( 200, $res->get_status() );
+
+	}
+
+	/**
+	 * An instructor can still read self and other instructor-role users.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_item_allows_instructor_targets() {
+
+		wp_set_current_user( $this->user_instructor );
+
+		// Self.
+		$res = $this->perform_mock_request( 'GET', $this->route . '/' . $this->user_instructor, array(), array( 'context' => 'edit' ) );
+		$this->assertEquals( 200, $res->get_status() );
+
+		// Another instructor.
+		$other = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		$res   = $this->perform_mock_request( 'GET', $this->route . '/' . $other, array(), array( 'context' => 'edit' ) );
+		$this->assertEquals( 200, $res->get_status() );
+
+		// Instructor's assistant.
+		$res = $this->perform_mock_request( 'GET', $this->route . '/' . $this->user_assistant, array(), array( 'context' => 'edit' ) );
+		$this->assertEquals( 200, $res->get_status() );
+
+	}
+
+	/**
+	 * The collection endpoint must not enumerate administrators via the roles param.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_items_does_not_enumerate_administrators() {
+
+		wp_set_current_user( $this->user_instructor );
+
+		$res = $this->perform_mock_request( 'GET', $this->route, array(), array( 'roles' => 'administrator', 'context' => 'edit' ) );
+		$this->assertEquals( 200, $res->get_status() );
+
+		$ids = wp_list_pluck( $res->get_data(), 'id' );
+		$this->assertNotContains( $this->user_admin, $ids );
+		$this->assertNotContains( $this->user_subscriber, $ids );
+
+	}
+
 	// public function test_update_item_auth() {}
 	// public function test_update_item_errors() {}
 	// public function test_update_item_success() {}

--- a/tests/unit-tests/server/class-llms-rest-test-lessons.php
+++ b/tests/unit-tests/server/class-llms-rest-test-lessons.php
@@ -722,6 +722,110 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test that an instructor cannot create a lesson inside a section/course they cannot edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_item_forbidden_parent_section() {
+
+		// Admin creates a victim course + section the instructor cannot edit.
+		wp_set_current_user( $this->user_allowed );
+		$victim_course = $this->factory->course->create_and_get(
+			array(
+				'sections' => 1,
+				'lessons'  => 0,
+			)
+		);
+		$victim_section_id = $victim_course->get_sections( 'ids' )[0];
+
+		// Act as an instructor who can publish lessons but cannot edit the victim section/course.
+		$instructor = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		wp_set_current_user( $instructor );
+
+		// Sanity: the instructor cannot edit the victim objects.
+		$this->assertFalse( current_user_can( 'edit_post', $victim_section_id ) );
+		$this->assertFalse( current_user_can( 'edit_post', $victim_course->get( 'id' ) ) );
+
+		// Control: the instructor can create an orphaned lesson (proves create permission isn't the blocker).
+		$res = $this->perform_mock_request( 'POST', $this->route, array_merge( $this->sample_lesson, array( 'parent_id' => 0 ) ) );
+		$this->assertResponseStatusEquals( 201, $res );
+
+		// Attack: inject a lesson into the victim section.
+		$res = $this->perform_mock_request(
+			'POST',
+			$this->route,
+			array_merge(
+				$this->sample_lesson,
+				array( 'parent_id' => $victim_section_id )
+			)
+		);
+
+		$this->assertResponseStatusEquals( 403, $res );
+		$this->assertResponseCodeEquals( 'llms_rest_forbidden_request', $res );
+
+		// Ensure no lesson was injected into the victim section.
+		$this->assertEmpty( $victim_course->get_lessons() );
+	}
+
+	/**
+	 * Test that an instructor cannot attach a quiz they cannot edit to a lesson they own.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_item_forbidden_quiz_attachment() {
+
+		// Admin creates a victim quiz the instructor cannot edit.
+		wp_set_current_user( $this->user_allowed );
+		$victim_course  = $this->factory->course->create_and_get(
+			array(
+				'sections' => 1,
+				'lessons'  => 1,
+				'quizzes'  => 1,
+			)
+		);
+		$victim_quiz_id = $victim_course->get_lessons()[0]->get( 'quiz' );
+		$this->assertTrue( $victim_quiz_id > 0 );
+
+		// Act as an instructor who owns their own course + lesson.
+		$instructor = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		wp_set_current_user( $instructor );
+		$attacker_course    = $this->factory->course->create_and_get(
+			array(
+				'sections' => 1,
+				'lessons'  => 1,
+				'quizzes'  => 0,
+			)
+		);
+		$attacker_lesson_id = $attacker_course->get_lessons( 'ids' )[0];
+
+		// Sanity: the instructor can edit their lesson but not the victim quiz.
+		$this->assertTrue( current_user_can( 'edit_post', $attacker_lesson_id ) );
+		$this->assertFalse( current_user_can( 'edit_post', $victim_quiz_id ) );
+
+		$res = $this->perform_mock_request(
+			'POST',
+			"{$this->route}/{$attacker_lesson_id}",
+			array(
+				'quiz' => array(
+					'enabled' => true,
+					'id'      => $victim_quiz_id,
+				),
+			)
+		);
+
+		$this->assertResponseStatusEquals( 403, $res );
+		$this->assertResponseCodeEquals( 'llms_rest_forbidden_request', $res );
+
+		// Ensure the victim quiz was NOT attached to the attacker lesson.
+		$lesson = llms_get_post( $attacker_lesson_id );
+		$this->assertEquals( 0, absint( $lesson->get( 'quiz' ) ) );
+	}
+
+	/**
 	 * Get resource creation args.
 	 *
 	 * @since 1.0.0-beta.27

--- a/tests/unit-tests/server/class-llms-rest-test-memberships.php
+++ b/tests/unit-tests/server/class-llms-rest-test-memberships.php
@@ -128,7 +128,7 @@ class LLMS_REST_Test_Memberships extends LLMS_REST_Unit_Test_Case_Posts {
 				'raw'      => 'Gold',
 			),
 			'content'      => array(
-				'rendered' => "\\n<h2 class=\"wp-block-heading\">Lorem ipsum dolor sit amet.</h2>\\n\\n\\n\\n<p>Expectoque quid ad id, quod quaerebam, respondeas. " .
+				'rendered' => "\\n<h2 class=\"wp-block-heading\">Lorem ipsum dolor sit amet.</h2>\\n\\n\\n\\n<p class=\"wp-block-paragraph\">Expectoque quid ad id, quod quaerebam, respondeas. " .
 				              "Nec enim, omnes avaritias si aeque avaritias esse dixerimus, sequetur ut etiam aequas esse dicamus.</p>\\n",
 				'raw'      => "<!-- wp:heading -->\\n<h2 class=\"wp-block-heading\">Lorem ipsum dolor sit amet.</h2>\\n<!-- /wp:heading -->\\n\\n<!-- wp:paragraph -->\\n<p>" .
 				              "Expectoque quid ad id, quod quaerebam, respondeas. Nec enim, " .

--- a/tests/unit-tests/server/class-llms-rest-test-sections.php
+++ b/tests/unit-tests/server/class-llms-rest-test-sections.php
@@ -207,6 +207,40 @@ class LLMS_REST_Test_Sections extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test that an instructor cannot create a section inside a course they cannot edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_section_forbidden_parent_course() {
+
+		// Admin creates a victim course the instructor cannot edit.
+		wp_set_current_user( $this->user_allowed );
+		$victim_course_id = $this->factory->course->create( array( 'sections' => 0 ) );
+
+		// Act as an instructor who can publish sections but cannot edit the victim course.
+		$instructor = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		wp_set_current_user( $instructor );
+
+		$this->assertFalse( current_user_can( 'edit_post', $victim_course_id ) );
+
+		$section_args              = $this->sample_section_args;
+		$section_args['parent_id'] = $victim_course_id;
+
+		$request = new WP_REST_Request( 'POST', $this->route );
+		$request->set_body_params( $section_args );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertResponseCodeEquals( 'llms_rest_forbidden_request', $response );
+
+		// Ensure no section was injected into the victim course.
+		$victim_course = new LLMS_Course( $victim_course_id );
+		$this->assertEmpty( $victim_course->get_sections() );
+	}
+
+	/**
 	 * Test producing bad request error when creating a single section.
 	 *
 	 * @since 1.0.0-beta.1


### PR DESCRIPTION
## Description

Additional checks on a couple of the REST API endpoints.

## How has this been tested?
Manually + PHPUnit tests

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

