### PR TITLE
Additional check when creating a key for a user

### DIFF
--- a/.changelogs/api-owner-checks.yml
+++ b/.changelogs/api-owner-checks.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: "Additional checks when assigning the owner of an API key."

--- a/includes/admin/class-llms-rest-admin-settings-api-keys.php
+++ b/includes/admin/class-llms-rest-admin-settings-api-keys.php
@@ -263,10 +263,17 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 	 */
 	protected static function save_create() {
 
+		$user_id = llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT );
+
+		$authorized = self::authorize_key_owner( $user_id );
+		if ( is_wp_error( $authorized ) ) {
+			return $authorized;
+		}
+
 		$create = LLMS_REST_API()->keys()->create(
 			array(
 				'description' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_description' ),
-				'user_id'     => llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT ),
+				'user_id'     => $user_id,
 				'permissions' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_permissions' ),
 			)
 		);
@@ -296,16 +303,41 @@ class LLMS_Rest_Admin_Settings_API_Keys {
 			return new WP_Error( 'llms_rest_api_key_not_found', sprintf( __( '"%s" is not a valid API Key.', 'lifterlms' ), $key_id ) );
 		}
 
+		$user_id = llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT );
+
+		$authorized = self::authorize_key_owner( $user_id );
+		if ( is_wp_error( $authorized ) ) {
+			return $authorized;
+		}
+
 		$update = LLMS_REST_API()->keys()->update(
 			array(
 				'id'          => $key_id,
 				'description' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_description' ),
-				'user_id'     => llms_filter_input( INPUT_POST, 'llms_rest_key_user_id', FILTER_SANITIZE_NUMBER_INT ),
+				'user_id'     => $user_id,
 				'permissions' => llms_filter_input_sanitize_string( INPUT_POST, 'llms_rest_key_permissions' ),
 			)
 		);
 
 		return $update;
+
+	}
+
+	/**
+	 * Ensure the current user is allowed to assign the requested key owner.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $user_id WP_User ID of the requested key owner.
+	 * @return WP_Error|true Returns `true` when authorized or a `WP_Error` when not.
+	 */
+	protected static function authorize_key_owner( $user_id ) {
+
+		if ( $user_id && ! current_user_can( 'edit_user', (int) $user_id ) ) {
+			return new WP_Error( 'llms_rest_key_invalid_user_id', __( 'You are not allowed to assign this user as the key owner.', 'lifterlms' ) );
+		}
+
+		return true;
 
 	}
 

--- a/tests/unit-tests/admin/class-llms-rest-test-admin-settings-api-keys.php
+++ b/tests/unit-tests/admin/class-llms-rest-test-admin-settings-api-keys.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Test the API Keys admin settings save handler.
+ *
+ * @package  LifterLMS_REST/Tests
+ *
+ * @group admin
+ * @group admin_settings_api_keys
+ *
+ * @since [version]
+ */
+class LLMS_REST_Test_Admin_Settings_API_Keys extends LLMS_REST_Unit_Test_Case_Base {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		parent::set_up();
+
+		// Ensure required classes are loaded.
+		set_current_screen( 'index.php' );
+		LLMS_REST_API()->includes();
+		include_once LLMS_REST_API_PLUGIN_DIR . 'includes/admin/class-llms-rest-admin-settings-page.php';
+
+		// Instantiating the page requires the API Keys settings class.
+		new LLMS_REST_Admin_Settings_Page();
+
+	}
+
+	/**
+	 * Tear down the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+
+		unset( $_GET['add-key'], $_GET['edit-key'] );
+		unset( $_POST['llms_rest_key_description'], $_POST['llms_rest_key_user_id'], $_POST['llms_rest_key_permissions'] );
+
+		parent::tear_down();
+
+	}
+
+	/**
+	 * Count the API keys owned by a given user.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $user_id WP_User ID.
+	 * @return int
+	 */
+	private function count_keys_for_user( $user_id ) {
+
+		$query = new LLMS_REST_API_Keys_Query(
+			array(
+				'user_id' => $user_id,
+			)
+		);
+
+		return count( $query->get_results() );
+
+	}
+
+	/**
+	 * An LMS Manager cannot create a key owned by a user they are not allowed to edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_create_rejects_unauthorized_owner() {
+
+		$manager = $this->factory->user->create( array( 'role' => 'lms_manager' ) );
+		$admin   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $manager );
+
+		$_GET['add-key']                   = '1';
+		$_POST['llms_rest_key_description'] = 'admin-key';
+		$_POST['llms_rest_key_user_id']    = $admin;
+		$_POST['llms_rest_key_permissions'] = 'read_write';
+
+		$ret = LLMS_Rest_Admin_Settings_API_Keys::save();
+
+		$this->assertWPErrorCodeEquals( 'llms_rest_key_invalid_user_id', $ret );
+		$this->assertEquals( 0, $this->count_keys_for_user( $admin ) );
+
+	}
+
+	/**
+	 * An LMS Manager can create a key owned by a user they are allowed to edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_create_allows_authorized_owner() {
+
+		$manager = $this->factory->user->create( array( 'role' => 'lms_manager' ) );
+		$student = $this->factory->user->create( array( 'role' => 'student' ) );
+
+		wp_set_current_user( $manager );
+
+		$_GET['add-key']                    = '1';
+		$_POST['llms_rest_key_description']  = 'student-key';
+		$_POST['llms_rest_key_user_id']     = $student;
+		$_POST['llms_rest_key_permissions'] = 'read_write';
+
+		$ret = LLMS_Rest_Admin_Settings_API_Keys::save();
+
+		$this->assertInstanceOf( 'LLMS_REST_API_Key', $ret );
+		$this->assertEquals( $student, $ret->get( 'user_id' ) );
+
+	}
+
+}


### PR DESCRIPTION

## Description
Verify user when creating API keys.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

